### PR TITLE
Drop the language param from a link

### DIFF
--- a/googleapis_auth/README.md
+++ b/googleapis_auth/README.md
@@ -296,5 +296,5 @@ client.close();
 ### More information
 
 More information can be obtained from official Google Developers documentation:
-- [OAuth2 to Access Google APIs](https://developers.google.com/accounts/docs/OAuth2?hl=fr)
+- [OAuth2 to Access Google APIs](https://developers.google.com/accounts/docs/OAuth2)
 - [OAuth2 Playground](https://developers.google.com/oauthplayground/)


### PR DESCRIPTION
Load the docs in the user's default language, instead of linking to the
docs in a particular language.