### PR TITLE
AutoRefreshingClient should close underlying client by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,19 @@ Here's a convenient list of the resources you might need:
 The following notes for those who are contributing to this package.
 If you are only using this package, you can skip this section.
 
+If you are only making changes to `googleapis_auth`, then you only need to run
+tests for that package and can skip the remainder of this section. Specifically,
+before submitting a pull request:
+
+  ```console
+  $ pushd googleapis_auth
+  $ pub get
+  $ pub run test
+  $ dart format . --fix
+  $ popd
+  ```
+Otherwise...
+
 * Clone this package and run `pub upgrade` from the `generator` directory.
 
   ```console
@@ -544,5 +557,3 @@ only available through a Limited Preview program:
   <a href="http://developers.google.com/products/">developers' products page</a>.
   Find the product you're interested in on that page and follow the link.
   Be sure to look the API reference docs for Dart as some of the Dart APIs have quirks.
-
-

--- a/googleapis_auth/lib/src/auth_http_utils.dart
+++ b/googleapis_auth/lib/src/auth_http_utils.dart
@@ -90,7 +90,7 @@ class AutoRefreshingClient extends AutoRefreshDelegatingClient {
     Client client,
     this.clientId,
     this.credentials, {
-    bool closeUnderlyingClient = false,
+    bool closeUnderlyingClient = true,
     this.quotaProject,
   })  : assert(credentials.accessToken.type == 'Bearer'),
         assert(credentials.refreshToken != null),

--- a/googleapis_auth/test/adc_test.dart
+++ b/googleapis_auth/test/adc_test.dart
@@ -50,7 +50,7 @@ void main() {
             return Response('hello world', 200);
           }
           return Response('bad', 404);
-        }, expectClose: false),
+        }),
       );
       expect(c.credentials.accessToken.data, equals('atoken'));
 
@@ -104,7 +104,7 @@ void main() {
             return Response('hello world', 200);
           }
           return Response('bad', 404);
-        }, expectClose: false),
+        }),
       );
       expect(c.credentials.accessToken.data, equals('atoken'));
 

--- a/googleapis_auth/test/oauth2_test.dart
+++ b/googleapis_auth/test/oauth2_test.dart
@@ -325,18 +325,17 @@ void main() {
         final client = autoRefreshingClient(
             clientId,
             credentials,
-            mockClient(
-                expectAsync1((request) {
-                  if (serverInvocation++ == 0) {
-                    // This should be a refresh request.
-                    expect(request.headers['foo'], isNull);
-                    return successfulRefresh(request);
-                  } else {
-                    // This is the real request.
-                    expect(request.headers['foo'], equals('bar'));
-                    return Future.value(Response('', 200));
-                  }
-                }, count: 2)));
+            mockClient(expectAsync1((request) {
+              if (serverInvocation++ == 0) {
+                // This should be a refresh request.
+                expect(request.headers['foo'], isNull);
+                return successfulRefresh(request);
+              } else {
+                // This is the real request.
+                expect(request.headers['foo'], equals('bar'));
+                return Future.value(Response('', 200));
+              }
+            }, count: 2)));
         expect(client.credentials, equals(credentials));
 
         var executed = false;

--- a/googleapis_auth/test/oauth2_test.dart
+++ b/googleapis_auth/test/oauth2_test.dart
@@ -336,8 +336,7 @@ void main() {
                     expect(request.headers['foo'], equals('bar'));
                     return Future.value(Response('', 200));
                   }
-                }, count: 2),
-                expectClose: false));
+                }, count: 2)));
         expect(client.credentials, equals(credentials));
 
         var executed = false;

--- a/mono_repo.yaml
+++ b/mono_repo.yaml
@@ -6,3 +6,4 @@ github:
 
 merge_stages:
 - analyze_and_format
+

--- a/mono_repo.yaml
+++ b/mono_repo.yaml
@@ -6,4 +6,3 @@ github:
 
 merge_stages:
 - analyze_and_format
-


### PR DESCRIPTION
Fixes #252

While there are a number of possible ways to address #252, this one:
- involves minimal code changes
- aligns `AutoRefreshingClient` with behavior of its abstract base classes (`AutoRefreshDelegatingClient`, and `DelegatingClient`).
- seems to satisfy the apparent expectation that for `clientViaApplicationDefaultCredentials()` that only an explicitly supplied base client (i.e., underlying client) should be wrapped with `nonClosingClient()`.