### PR TITLE
Escape brackets

### DIFF
--- a/discoveryapis_generator/lib/src/dart_comments.dart
+++ b/discoveryapis_generator/lib/src/dart_comments.dart
@@ -5,7 +5,7 @@
 library discoveryapis_generator.dart_comments;
 
 final _markdownToEscape =
-    {'[', ']', '`'}.map((e) => RegExp('([\\\\]*)(\\$e)')).toSet();
+    {'[', ']', '<', '>', '`'}.map((e) => RegExp('([\\\\]*)(\\$e)')).toSet();
 
 String markdownEscape(String input) {
   for (var pattern in _markdownToEscape) {

--- a/generated/googleapis/lib/accesscontextmanager/v1.dart
+++ b/generated/googleapis/lib/accesscontextmanager/v1.dart
@@ -1924,7 +1924,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"

--- a/generated/googleapis/lib/admin/directory_v1.dart
+++ b/generated/googleapis/lib/admin/directory_v1.dart
@@ -535,7 +535,7 @@ class ChromeosdevicesResource {
   /// - "notes" : Chrome device notes as annotated by the administrator.
   /// - "serialNumber" : The Chrome device serial number entered when the device
   /// was enabled.
-  /// - "status" : Chrome device status. For more information, see the <a
+  /// - "status" : Chrome device status. For more information, see the \<a
   /// \[chromeosdevices\](/admin-sdk/directory/v1/reference/chromeosdevices.html).
   /// - "supportEndDate" : Chrome device support end date. This is applicable
   /// only for devices purchased directly from Google.
@@ -7291,8 +7291,8 @@ class ChromeOsDeviceSystemRamFreeReports {
 class ChromeOsDeviceTpmVersionInfo {
   /// TPM family.
   ///
-  /// We use the TPM 2.0 style encoding, e.g.: TPM 1.2: "1.2" -> 312e3200 TPM
-  /// 2.0: "2.0" -> 322e3000
+  /// We use the TPM 2.0 style encoding, e.g.: TPM 1.2: "1.2" -\> 312e3200 TPM
+  /// 2.0: "2.0" -\> 322e3000
   core.String? family;
 
   /// TPM firmware version.

--- a/generated/googleapis/lib/admin/reports_v1.dart
+++ b/generated/googleapis/lib/admin/reports_v1.dart
@@ -196,16 +196,16 @@ class ActivitiesResource {
   /// filtered request's parameter does not belong to the `eventName`. For more
   /// information about `eventName` parameters, see the list of event names for
   /// various applications above in `applicationName`. In the following Admin
-  /// Activity example, the <> operator is URL-encoded in the request's query
+  /// Activity example, the \<\> operator is URL-encoded in the request's query
   /// string (%3C%3E): GET...&eventName=CHANGE_CALENDAR_SETTING
   /// &filters=NEW_VALUE%3C%3EREAD_ONLY_ACCESS In the following Drive example,
   /// the list can be a view or edit event's `doc_id` parameter with a value
-  /// that is manipulated by an 'equal to' (==) or 'not equal to' (<>)
+  /// that is manipulated by an 'equal to' (==) or 'not equal to' (\<\>)
   /// relational operator. In the first example, the report returns each edited
   /// document's `doc_id`. In the second example, the report returns each viewed
   /// document's `doc_id` that equals the value 12345 and does not return any
-  /// viewed document's which have a `doc_id` value of 98765. The <> operator is
-  /// URL-encoded in the request's query string (%3C%3E):
+  /// viewed document's which have a `doc_id` value of 98765. The \<\> operator
+  /// is URL-encoded in the request's query string (%3C%3E):
   /// GET...&eventName=edit&filters=doc_id
   /// GET...&eventName=view&filters=doc_id==12345,doc_id%3C%3E98765 The
   /// relational operators include: - `==` - 'equal to'. - `<>` - 'not equal
@@ -220,7 +220,7 @@ class ActivitiesResource {
   /// returns the response corresponding to the remaining valid request
   /// parameters. If no parameters are requested, all parameters are returned.
   /// Value must have pattern
-  /// `(.+\[<,<=,==,>=,>,<>\].+,)*(.+\[<,<=,==,>=,>,<>\].+)`.
+  /// `(.+\[\<,\<=,==,\>=,\>,\<\>\].+,)*(.+\[\<,\<=,==,\>=,\>,\<\>\].+)`.
   ///
   /// [groupIdFilter] - Comma separated group ids (obfuscated) on which user
   /// activities are filtered, i.e. the response will contain activities for
@@ -424,16 +424,16 @@ class ActivitiesResource {
   /// filtered request's parameter does not belong to the `eventName`. For more
   /// information about `eventName` parameters, see the list of event names for
   /// various applications above in `applicationName`. In the following Admin
-  /// Activity example, the <> operator is URL-encoded in the request's query
+  /// Activity example, the \<\> operator is URL-encoded in the request's query
   /// string (%3C%3E): GET...&eventName=CHANGE_CALENDAR_SETTING
   /// &filters=NEW_VALUE%3C%3EREAD_ONLY_ACCESS In the following Drive example,
   /// the list can be a view or edit event's `doc_id` parameter with a value
-  /// that is manipulated by an 'equal to' (==) or 'not equal to' (<>)
+  /// that is manipulated by an 'equal to' (==) or 'not equal to' (\<\>)
   /// relational operator. In the first example, the report returns each edited
   /// document's `doc_id`. In the second example, the report returns each viewed
   /// document's `doc_id` that equals the value 12345 and does not return any
-  /// viewed document's which have a `doc_id` value of 98765. The <> operator is
-  /// URL-encoded in the request's query string (%3C%3E):
+  /// viewed document's which have a `doc_id` value of 98765. The \<\> operator
+  /// is URL-encoded in the request's query string (%3C%3E):
   /// GET...&eventName=edit&filters=doc_id
   /// GET...&eventName=view&filters=doc_id==12345,doc_id%3C%3E98765 The
   /// relational operators include: - `==` - 'equal to'. - `<>` - 'not equal
@@ -448,7 +448,7 @@ class ActivitiesResource {
   /// returns the response corresponding to the remaining valid request
   /// parameters. If no parameters are requested, all parameters are returned.
   /// Value must have pattern
-  /// `(.+\[<,<=,==,>=,>,<>\].+,)*(.+\[<,<=,==,>=,>,<>\].+)`.
+  /// `(.+\[\<,\<=,==,\>=,\>,\<\>\].+,)*(.+\[\<,\<=,==,\>=,\>,\<\>\].+)`.
   ///
   /// [groupIdFilter] - Comma separated group ids (obfuscated) on which user
   /// activities are filtered, i.e. the response will contain activities for
@@ -713,7 +713,7 @@ class EntityUsageReportsResource {
   /// (%3E). - `>=` - 'greater than or equal to'. It is URL-encoded (%3E=).
   /// Filters can only be applied to numeric parameters.
   /// Value must have pattern
-  /// `(((gplus)):\[a-z0-9_\]+\[<,<=,==,>=,>,!=\]\[^,\]+,)*(((gplus)):\[a-z0-9_\]+\[<,<=,==,>=,>,!=\]\[^,\]+)`.
+  /// `(((gplus)):\[a-z0-9_\]+\[\<,\<=,==,\>=,\>,!=\]\[^,\]+,)*(((gplus)):\[a-z0-9_\]+\[\<,\<=,==,\>=,\>,!=\]\[^,\]+)`.
   ///
   /// [maxResults] - Determines how many activity records are shown on each
   /// response page. For example, if the request sets `maxResults=1` and the
@@ -834,7 +834,7 @@ class UserUsageReportResource {
   /// 'greater than'. It is URL-encoded (%3E). - `>=` - 'greater than or equal
   /// to'. It is URL-encoded (%3E=).
   /// Value must have pattern
-  /// `(((accounts)|(classroom)|(cros)|(gmail)|(calendar)|(docs)|(gplus)|(sites)|(device_management)|(drive)):\[a-z0-9_\]+\[<,<=,==,>=,>,!=\]\[^,\]+,)*(((accounts)|(classroom)|(cros)|(gmail)|(calendar)|(docs)|(gplus)|(sites)|(device_management)|(drive)):\[a-z0-9_\]+\[<,<=,==,>=,>,!=\]\[^,\]+)`.
+  /// `(((accounts)|(classroom)|(cros)|(gmail)|(calendar)|(docs)|(gplus)|(sites)|(device_management)|(drive)):\[a-z0-9_\]+\[\<,\<=,==,\>=,\>,!=\]\[^,\]+,)*(((accounts)|(classroom)|(cros)|(gmail)|(calendar)|(docs)|(gplus)|(sites)|(device_management)|(drive)):\[a-z0-9_\]+\[\<,\<=,==,\>=,\>,!=\]\[^,\]+)`.
   ///
   /// [groupIdFilter] - Comma separated group ids (obfuscated) on which user
   /// activities are filtered, i.e. the response will contain activities for

--- a/generated/googleapis/lib/admob/v1.dart
+++ b/generated/googleapis/lib/admob/v1.dart
@@ -947,7 +947,7 @@ class LocalizationSettings {
 /// "currency_code": "USD", "language_code": "en-US" } } For a better
 /// understanding, you can treat the preceding specification like the following
 /// pseudo SQL: SELECT AD_SOURCE, APP, COUNTRY, OBSERVED_ECPM FROM
-/// MEDIATION_REPORT WHERE DATE >= '2021-09-01' AND DATE <= '2021-09-30' AND
+/// MEDIATION_REPORT WHERE DATE \>= '2021-09-01' AND DATE \<= '2021-09-30' AND
 /// COUNTRY IN ('US', 'CN') GROUP BY AD_SOURCE, APP, COUNTRY ORDER BY APP ASC;
 class MediationReportSpec {
   /// The date range for which the report is generated.
@@ -1252,8 +1252,8 @@ class MediationReportSpecSortCondition {
 /// 'DESCENDING'} \], 'localization_settings': { 'currency_code': 'USD',
 /// 'language_code': 'en-US' } } For a better understanding, you can treat the
 /// preceding specification like the following pseudo SQL: SELECT DATE, APP,
-/// COUNTRY, CLICKS, ESTIMATED_EARNINGS FROM NETWORK_REPORT WHERE DATE >=
-/// '2021-09-01' AND DATE <= '2021-09-30' AND COUNTRY IN ('US', 'CN') GROUP BY
+/// COUNTRY, CLICKS, ESTIMATED_EARNINGS FROM NETWORK_REPORT WHERE DATE \>=
+/// '2021-09-01' AND DATE \<= '2021-09-30' AND COUNTRY IN ('US', 'CN') GROUP BY
 /// DATE, APP, COUNTRY ORDER BY APP ASC, CLICKS DESC;
 class NetworkReportSpec {
   /// The date range for which the report is generated.

--- a/generated/googleapis/lib/analyticsreporting/v4.dart
+++ b/generated/googleapis/lib/analyticsreporting/v4.dart
@@ -599,18 +599,18 @@ class Dimension {
   /// boundary, the "last" bucket includes all values up to infinity. Dimension
   /// values that fall in a bucket get transformed to a new dimension value. For
   /// example, if one gives a list of "0, 1, 3, 4, 7", then we return the
-  /// following buckets: - bucket #1: values < 0, dimension value "<0" - bucket
-  /// #2: values in \[0,1), dimension value "0" - bucket #3: values in \[1,3),
-  /// dimension value "1-2" - bucket #4: values in \[3,4), dimension value "3" -
-  /// bucket #5: values in \[4,7), dimension value "4-6" - bucket #6: values >=
-  /// 7, dimension value "7+" NOTE: If you are applying histogram mutation on
-  /// any dimension, and using that dimension in sort, you will want to use the
-  /// sort type `HISTOGRAM_BUCKET` for that purpose. Without that the dimension
-  /// values will be sorted according to dictionary (lexicographic) order. For
-  /// example the ascending dictionary order is: "<50", "1001+", "121-1000",
-  /// "50-120" And the ascending `HISTOGRAM_BUCKET` order is: "<50", "50-120",
-  /// "121-1000", "1001+" The client has to explicitly request `"orderType":
-  /// "HISTOGRAM_BUCKET"` for a histogram-mutated dimension.
+  /// following buckets: - bucket #1: values \< 0, dimension value "\<0" -
+  /// bucket #2: values in \[0,1), dimension value "0" - bucket #3: values in
+  /// \[1,3), dimension value "1-2" - bucket #4: values in \[3,4), dimension
+  /// value "3" - bucket #5: values in \[4,7), dimension value "4-6" - bucket
+  /// #6: values \>= 7, dimension value "7+" NOTE: If you are applying histogram
+  /// mutation on any dimension, and using that dimension in sort, you will want
+  /// to use the sort type `HISTOGRAM_BUCKET` for that purpose. Without that the
+  /// dimension values will be sorted according to dictionary (lexicographic)
+  /// order. For example the ascending dictionary order is: "\<50", "1001+",
+  /// "121-1000", "50-120" And the ascending `HISTOGRAM_BUCKET` order is:
+  /// "\<50", "50-120", "121-1000", "1001+" The client has to explicitly request
+  /// `"orderType": "HISTOGRAM_BUCKET"` for a histogram-mutated dimension.
   core.List<core.String>? histogramBuckets;
 
   /// Name of the dimension to fetch, for example `ga:browser`.
@@ -1980,7 +1980,7 @@ class ReportRequest {
 
   /// Page size is for paging and specifies the maximum number of returned rows.
   ///
-  /// Page size should be >= 0. A query returns the default of 1,000 rows. The
+  /// Page size should be \>= 0. A query returns the default of 1,000 rows. The
   /// Analytics Core Reporting API returns a maximum of 100,000 rows per
   /// request, no matter how many you ask for. It can also return fewer rows
   /// than requested, if there aren't as many dimension segments as you expect.
@@ -2292,7 +2292,7 @@ class SearchUserActivityRequest {
 
   /// Page size is for paging and specifies the maximum number of returned rows.
   ///
-  /// Page size should be > 0. If the value is 0 or if the field isn't
+  /// Page size should be \> 0. If the value is 0 or if the field isn't
   /// specified, the request returns the default of 1000 rows per page.
   core.int? pageSize;
 

--- a/generated/googleapis/lib/androidenterprise/v1.dart
+++ b/generated/googleapis/lib/androidenterprise/v1.dart
@@ -365,7 +365,7 @@ class DevicesResource {
   ///
   /// [updateMask] - Mask that identifies which fields to update. If not set,
   /// all modifiable fields will be modified. When set in a query parameter,
-  /// this field should be specified as updateMask=<field1>,<field2>,...
+  /// this field should be specified as updateMask=\<field1\>,\<field2\>,...
   ///
   /// [$fields] - Selector specifying which fields to include in a partial
   /// response.
@@ -6161,7 +6161,7 @@ class Product {
   /// A list of permissions required by the app.
   core.List<ProductPermission>? permissions;
 
-  /// A string of the form *app:<package name>*.
+  /// A string of the form *app:\<package name\>*.
   ///
   /// For example, app:com.google.android.gm represents the Gmail app.
   core.String? productId;
@@ -7476,7 +7476,7 @@ class WebApp {
 
   /// The ID of the application.
   ///
-  /// A string of the form "app:<package name>" where the package name always
+  /// A string of the form "app:\<package name\>" where the package name always
   /// starts with the prefix "com.google.enterprise.webapp." followed by a
   /// random id.
   core.String? webAppId;

--- a/generated/googleapis/lib/androidmanagement/v1.dart
+++ b/generated/googleapis/lib/androidmanagement/v1.dart
@@ -3414,8 +3414,8 @@ class Enterprise {
   /// A color in RGB format that indicates the predominant color to display in
   /// the device management app UI.
   ///
-  /// The color components are stored as follows: (red << 16) | (green << 8) |
-  /// blue, where the value of each component is between 0 and 255, inclusive.
+  /// The color components are stored as follows: (red \<\< 16) | (green \<\< 8)
+  /// | blue, where the value of each component is between 0 and 255, inclusive.
   core.int? primaryColor;
 
   /// The topic that Cloud Pub/Sub notifications are published to, in the form
@@ -3915,7 +3915,7 @@ class KeyedAppState {
   /// Optionally, a machine-readable value to be read by the EMM.
   ///
   /// For example, setting values that the admin can choose to query against in
-  /// the EMM console (e.g. “notify me if the battery_warning data < 10”).
+  /// the EMM console (e.g. “notify me if the battery_warning data \< 10”).
   core.String? data;
 
   /// The key for the app state.

--- a/generated/googleapis/lib/androidpublisher/v3.dart
+++ b/generated/googleapis/lib/androidpublisher/v3.dart
@@ -6380,7 +6380,8 @@ class TrackRelease {
 
   /// Fraction of users who are eligible for a staged release.
   ///
-  /// 0 < fraction < 1. Can only be set when status is "inProgress" or "halted".
+  /// 0 \< fraction \< 1. Can only be set when status is "inProgress" or
+  /// "halted".
   core.double? userFraction;
 
   /// Version codes of all APKs in the release.

--- a/generated/googleapis/lib/apigateway/v1.dart
+++ b/generated/googleapis/lib/apigateway/v1.dart
@@ -2048,7 +2048,7 @@ typedef ApigatewayCancelOperationRequest = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -2597,14 +2597,14 @@ class ApigatewayOperationMetadataDiagnostic {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class ApigatewayPolicy {

--- a/generated/googleapis/lib/apigee/v1.dart
+++ b/generated/googleapis/lib/apigee/v1.dart
@@ -21707,14 +21707,14 @@ class GoogleIamV1Binding {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class GoogleIamV1Policy {
@@ -22055,7 +22055,7 @@ typedef GoogleRpcStatus = $Status;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"

--- a/generated/googleapis/lib/bigquery/v2.dart
+++ b/generated/googleapis/lib/bigquery/v2.dart
@@ -248,8 +248,8 @@ class DatasetsResource {
   /// [all] - Whether to list all datasets, including hidden ones
   ///
   /// [filter] - An expression for filtering the results of the request by
-  /// label. The syntax is "labels.<name>\[:<value>\]". Multiple filters can be
-  /// ANDed together by connecting with a space. Example:
+  /// label. The syntax is "labels.\<name\>\[:\<value\>\]". Multiple filters can
+  /// be ANDed together by connecting with a space. Example:
   /// "labels.department:receiving labels.active". See Filtering datasets using
   /// labels for details.
   ///
@@ -3957,8 +3957,8 @@ class CsvOptions {
   /// headers in the first row. If they are not detected, the row is read as
   /// data. Otherwise data is read starting from the second row. *
   /// skipLeadingRows is 0 - Instructs autodetect that there are no headers and
-  /// data should be read starting from the first row. * skipLeadingRows = N > 0
-  /// - Autodetect skips N-1 rows and tries to detect headers in row N. If
+  /// data should be read starting from the first row. * skipLeadingRows = N \>
+  /// 0 - Autodetect skips N-1 rows and tries to detect headers in row N. If
   /// headers are not detected, row N is just skipped. Otherwise row N is used
   /// to extract column names for the detected schema.
   ///
@@ -4768,7 +4768,7 @@ class Entry {
 
   /// The predicted label.
   ///
-  /// For confidence_threshold > 0, we will also add an entry indicating the
+  /// For confidence_threshold \> 0, we will also add an entry indicating the
   /// number of items under the confidence threshold.
   core.String? predictedLabel;
 
@@ -5210,7 +5210,7 @@ class ExplainQueryStep {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -5264,15 +5264,15 @@ class ExternalDataConfiguration {
   /// the type supporting the widest range in the specified list is picked, and
   /// if a value exceeds the supported range when reading the data, an error
   /// will be thrown. Example: Suppose the value of this field is \["NUMERIC",
-  /// "BIGNUMERIC"\]. If (precision,scale) is: (38,9) -> NUMERIC; (39,9) ->
-  /// BIGNUMERIC (NUMERIC cannot hold 30 integer digits); (38,10) -> BIGNUMERIC
-  /// (NUMERIC cannot hold 10 fractional digits); (76,38) -> BIGNUMERIC; (77,38)
-  /// -> BIGNUMERIC (error if value exeeds supported range). This field cannot
-  /// contain duplicate types. The order of the types in this field is ignored.
-  /// For example, \["BIGNUMERIC", "NUMERIC"\] is the same as \["NUMERIC",
-  /// "BIGNUMERIC"\] and NUMERIC always takes precedence over BIGNUMERIC.
-  /// Defaults to \["NUMERIC", "STRING"\] for ORC and \["NUMERIC"\] for the
-  /// other file formats.
+  /// "BIGNUMERIC"\]. If (precision,scale) is: (38,9) -\> NUMERIC; (39,9) -\>
+  /// BIGNUMERIC (NUMERIC cannot hold 30 integer digits); (38,10) -\> BIGNUMERIC
+  /// (NUMERIC cannot hold 10 fractional digits); (76,38) -\> BIGNUMERIC;
+  /// (77,38) -\> BIGNUMERIC (error if value exeeds supported range). This field
+  /// cannot contain duplicate types. The order of the types in this field is
+  /// ignored. For example, \["BIGNUMERIC", "NUMERIC"\] is the same as
+  /// \["NUMERIC", "BIGNUMERIC"\] and NUMERIC always takes precedence over
+  /// BIGNUMERIC. Defaults to \["NUMERIC", "STRING"\] for ORC and \["NUMERIC"\]
+  /// for the other file formats.
   ///
   /// Optional.
   core.List<core.String>? decimalTargetTypes;
@@ -5699,7 +5699,7 @@ class GoogleSheetsOptions {
   /// first row. If they are not detected, the row is read as data. Otherwise
   /// data is read starting from the second row. * skipLeadingRows is 0 -
   /// Instructs autodetect that there are no headers and data should be read
-  /// starting from the first row. * skipLeadingRows = N > 0 - Autodetect skips
+  /// starting from the first row. * skipLeadingRows = N \> 0 - Autodetect skips
   /// N-1 rows and tries to detect headers in row N. If headers are not
   /// detected, row N is just skipped. Otherwise row N is used to extract column
   /// names for the detected schema.
@@ -6252,15 +6252,15 @@ class JobConfigurationLoad {
   /// the type supporting the widest range in the specified list is picked, and
   /// if a value exceeds the supported range when reading the data, an error
   /// will be thrown. Example: Suppose the value of this field is \["NUMERIC",
-  /// "BIGNUMERIC"\]. If (precision,scale) is: (38,9) -> NUMERIC; (39,9) ->
-  /// BIGNUMERIC (NUMERIC cannot hold 30 integer digits); (38,10) -> BIGNUMERIC
-  /// (NUMERIC cannot hold 10 fractional digits); (76,38) -> BIGNUMERIC; (77,38)
-  /// -> BIGNUMERIC (error if value exeeds supported range). This field cannot
-  /// contain duplicate types. The order of the types in this field is ignored.
-  /// For example, \["BIGNUMERIC", "NUMERIC"\] is the same as \["NUMERIC",
-  /// "BIGNUMERIC"\] and NUMERIC always takes precedence over BIGNUMERIC.
-  /// Defaults to \["NUMERIC", "STRING"\] for ORC and \["NUMERIC"\] for the
-  /// other file formats.
+  /// "BIGNUMERIC"\]. If (precision,scale) is: (38,9) -\> NUMERIC; (39,9) -\>
+  /// BIGNUMERIC (NUMERIC cannot hold 30 integer digits); (38,10) -\> BIGNUMERIC
+  /// (NUMERIC cannot hold 10 fractional digits); (76,38) -\> BIGNUMERIC;
+  /// (77,38) -\> BIGNUMERIC (error if value exeeds supported range). This field
+  /// cannot contain duplicate types. The order of the types in this field is
+  /// ignored. For example, \["BIGNUMERIC", "NUMERIC"\] is the same as
+  /// \["NUMERIC", "BIGNUMERIC"\] and NUMERIC always takes precedence over
+  /// BIGNUMERIC. Defaults to \["NUMERIC", "STRING"\] for ORC and \["NUMERIC"\]
+  /// for the other file formats.
   ///
   /// Optional.
   core.List<core.String>? decimalTargetTypes;
@@ -7332,7 +7332,7 @@ class JobStatisticsReservationUsage {
 }
 
 class JobStatistics {
-  /// \[TrustedTester\] \[Output-only\] Job progress (0.0 -> 1.0) for LOAD and
+  /// \[TrustedTester\] \[Output-only\] Job progress (0.0 -\> 1.0) for LOAD and
   /// EXTRACT jobs.
   core.double? completionRatio;
 
@@ -8684,14 +8684,14 @@ class ParquetOptions {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {
@@ -10346,7 +10346,7 @@ class SnapshotDefinition {
 /// The type of a variable, e.g., a function argument.
 ///
 /// Examples: INT64: {type_kind="INT64"} ARRAY: {type_kind="ARRAY",
-/// array_element_type="STRING"} STRUCT>: {type_kind="STRUCT",
+/// array_element_type="STRING"} STRUCT\>: {type_kind="STRUCT",
 /// struct_type={fields=\[ {name="x", type={type_kind="STRING"}}, {name="y",
 /// type={type_kind="ARRAY", array_element_type="DATE"}} \]}}
 class StandardSqlDataType {
@@ -12346,7 +12346,7 @@ class TrainingRun {
   /// end of training.
   EvaluationMetrics? evaluationMetrics;
 
-  /// Output of each iteration run, results.size() <= max_iterations.
+  /// Output of each iteration run, results.size() \<= max_iterations.
   core.List<IterationResult>? results;
 
   /// The start time of this training run.

--- a/generated/googleapis/lib/bigqueryreservation/v1.dart
+++ b/generated/googleapis/lib/bigqueryreservation/v1.dart
@@ -130,7 +130,7 @@ class ProjectsLocationsResource {
   /// on the organization will be returned (organization doesn't have
   /// ancestors). Comparing to ListAssignments, there are some behavior
   /// differences: 1. permission on the assignee will be verified in this API.
-  /// 2. Hierarchy lookup (project->folder->organization) happens in this API.
+  /// 2. Hierarchy lookup (project-\>folder-\>organization) happens in this API.
   /// 3. Parent here is `projects / * /locations / * `, instead of `projects / *
   /// /locations / * reservations / * `.
   ///
@@ -196,7 +196,7 @@ class ProjectsLocationsResource {
   /// on the organization will be returned (organization doesn't have
   /// ancestors). Comparing to ListAssignments, there are some behavior
   /// differences: 1. permission on the assignee will be verified in this API.
-  /// 2. Hierarchy lookup (project->folder->organization) happens in this API.
+  /// 2. Hierarchy lookup (project-\>folder-\>organization) happens in this API.
   /// 3. Parent here is `projects / * /locations / * `, instead of `projects / *
   /// /locations / * reservations / * `. **Note** "-" cannot be used for
   /// projects nor locations.

--- a/generated/googleapis/lib/bigtableadmin/v2.dart
+++ b/generated/googleapis/lib/bigtableadmin/v2.dart
@@ -1426,24 +1426,24 @@ class ProjectsInstancesClustersBackupsResource {
   /// [filter] - A filter expression that filters backups listed in the
   /// response. The expression must specify the field name, a comparison
   /// operator, and the value that you want to use for filtering. The value must
-  /// be a string, a number, or a boolean. The comparison operator must be <, >,
-  /// <=, >=, !=, =, or :. Colon ':' represents a HAS operator which is roughly
-  /// synonymous with equality. Filter rules are case insensitive. The fields
-  /// eligible for filtering are: * `name` * `source_table` * `state` *
+  /// be a string, a number, or a boolean. The comparison operator must be \<,
+  /// \>, \<=, \>=, !=, =, or :. Colon ':' represents a HAS operator which is
+  /// roughly synonymous with equality. Filter rules are case insensitive. The
+  /// fields eligible for filtering are: * `name` * `source_table` * `state` *
   /// `start_time` (and values are of the format YYYY-MM-DDTHH:MM:SSZ) *
   /// `end_time` (and values are of the format YYYY-MM-DDTHH:MM:SSZ) *
   /// `expire_time` (and values are of the format YYYY-MM-DDTHH:MM:SSZ) *
   /// `size_bytes` To filter on multiple expressions, provide each separate
   /// expression within parentheses. By default, each expression is an AND
   /// expression. However, you can include AND, OR, and NOT expressions
-  /// explicitly. Some examples of using filters are: * `name:"exact"` --> The
-  /// backup's name is the string "exact". * `name:howl` --> The backup's name
-  /// contains the string "howl". * `source_table:prod` --> The source_table's
-  /// name contains the string "prod". * `state:CREATING` --> The backup is
-  /// pending creation. * `state:READY` --> The backup is fully created and
+  /// explicitly. Some examples of using filters are: * `name:"exact"` --\> The
+  /// backup's name is the string "exact". * `name:howl` --\> The backup's name
+  /// contains the string "howl". * `source_table:prod` --\> The source_table's
+  /// name contains the string "prod". * `state:CREATING` --\> The backup is
+  /// pending creation. * `state:READY` --\> The backup is fully created and
   /// ready for use. * `(name:howl) AND (start_time < \"2018-03-28T14:50:00Z\")`
-  /// --> The backup name contains the string "howl" and start_time of the
-  /// backup is before 2018-03-28T14:50:00Z. * `size_bytes > 10000000000` -->
+  /// --\> The backup name contains the string "howl" and start_time of the
+  /// backup is before 2018-03-28T14:50:00Z. * `size_bytes > 10000000000` --\>
   /// The backup's size is greater than 10GB
   ///
   /// [orderBy] - An expression for specifying the sort order of the results of
@@ -3393,7 +3393,7 @@ class EncryptionInfo {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -4246,14 +4246,14 @@ class PartialUpdateInstanceRequest {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/binaryauthorization/v1.dart
+++ b/generated/googleapis/lib/binaryauthorization/v1.dart
@@ -1155,7 +1155,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -1190,14 +1190,14 @@ typedef Expr = $Expr;
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class IamPolicy {

--- a/generated/googleapis/lib/chat/v1.dart
+++ b/generated/googleapis/lib/chat/v1.dart
@@ -1504,7 +1504,7 @@ class CardHeader {
 /// toProto(UIColor* color) { CGFloat red, green, blue, alpha; if (!\[color
 /// getRed:&red green:&green blue:&blue alpha:&alpha\]) { return nil; } Color*
 /// result = \[\[Color alloc\] init\]; \[result setRed:red\]; \[result
-/// setGreen:green\]; \[result setBlue:blue\]; if (alpha <= 0.9999) { \[result
+/// setGreen:green\]; \[result setBlue:blue\]; if (alpha \<= 0.9999) { \[result
 /// setAlpha:floatWrapperWithValue(alpha)\]; } \[result autorelease\]; return
 /// result; } // ... Example (JavaScript): // ... var protoToCssColor =
 /// function(rgb_color) { var redFrac = rgb_color.red || 0.0; var greenFrac =
@@ -1514,10 +1514,10 @@ class CardHeader {
 /// rgbToCssColor(red, green, blue); } var alphaFrac = rgb_color.alpha.value ||
 /// 0.0; var rgbParams = \[red, green, blue\].join(','); return \['rgba(',
 /// rgbParams, ',', alphaFrac, ')'\].join(''); }; var rgbToCssColor =
-/// function(red, green, blue) { var rgbNumber = new Number((red << 16) | (green
-/// << 8) | blue); var hexString = rgbNumber.toString(16); var missingZeros = 6
-/// - hexString.length; var resultBuilder = \['#'\]; for (var i = 0; i <
-/// missingZeros; i++) { resultBuilder.push('0'); }
+/// function(red, green, blue) { var rgbNumber = new Number((red \<\< 16) |
+/// (green \<\< 8) | blue); var hexString = rgbNumber.toString(16); var
+/// missingZeros = 6 - hexString.length; var resultBuilder = \['#'\]; for (var i
+/// = 0; i \< missingZeros; i++) { resultBuilder.push('0'); }
 /// resultBuilder.push(hexString); return resultBuilder.join(''); }; // ...
 typedef Color = $Color;
 

--- a/generated/googleapis/lib/chromepolicy/v1.dart
+++ b/generated/googleapis/lib/chromepolicy/v1.dart
@@ -1372,7 +1372,7 @@ class Proto2FieldDescriptorProto {
   ///
   /// For booleans, "true" or "false". For strings, contains the default text
   /// contents (not escaped in any way). For bytes, contains the C escaped
-  /// value. All bytes >= 128 are escaped.
+  /// value. All bytes \>= 128 are escaped.
   core.String? defaultValue;
 
   /// JSON name of this field.

--- a/generated/googleapis/lib/cloudasset/v1.dart
+++ b/generated/googleapis/lib/cloudasset/v1.dart
@@ -1684,7 +1684,7 @@ class BigQueryDestination {
   /// nested fields in the Asset.resource.data field of that asset type (up to
   /// the 15 nested level BigQuery supports
   /// (https://cloud.google.com/bigquery/docs/nested-repeated#limitations)). The
-  /// fields in >15 nested levels will be stored in JSON format string as a
+  /// fields in \>15 nested levels will be stored in JSON format string as a
   /// child column of its parent RECORD column. If error occurs when exporting
   /// to any table, the whole export call will return an error but the export
   /// results that already succeed will persist. Example: if exporting to
@@ -2071,7 +2071,7 @@ class ExportAssetsRequest {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -5007,14 +5007,14 @@ class Permissions {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/cloudbilling/v1.dart
+++ b/generated/googleapis/lib/cloudbilling/v1.dart
@@ -1037,7 +1037,7 @@ class Category {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -1259,14 +1259,14 @@ typedef Money = $Money;
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/cloudfunctions/v1.dart
+++ b/generated/googleapis/lib/cloudfunctions/v1.dart
@@ -1437,7 +1437,7 @@ class EventTrigger {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -1888,14 +1888,14 @@ class OperationMetadataV1 {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/cloudiot/v1.dart
+++ b/generated/googleapis/lib/cloudiot/v1.dart
@@ -2011,7 +2011,7 @@ class EventNotificationConfig {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -2362,14 +2362,14 @@ class MqttConfig {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/cloudkms/v1.dart
+++ b/generated/googleapis/lib/cloudkms/v1.dart
@@ -3281,7 +3281,7 @@ class EncryptResponse {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -4358,14 +4358,14 @@ class MacVerifyResponse {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/cloudprofiler/v2.dart
+++ b/generated/googleapis/lib/cloudprofiler/v2.dart
@@ -267,8 +267,8 @@ class Deployment {
   /// Labels identify the deployment within the user universe and same target.
   ///
   /// Validation regex for label names: `^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`.
-  /// Value for an individual label must be <= 512 bytes, the total size of all
-  /// label names and values must be <= 1024 bytes. Label named "language" can
+  /// Value for an individual label must be \<= 512 bytes, the total size of all
+  /// label names and values must be \<= 1024 bytes. Label named "language" can
   /// be used to record the programming language of the profiled deployment. The
   /// standard choices for the value include "java", "go", "python", "ruby",
   /// "nodejs", "php", "dotnet". For deployments running on Google Cloud

--- a/generated/googleapis/lib/cloudresourcemanager/v1.dart
+++ b/generated/googleapis/lib/cloudresourcemanager/v1.dart
@@ -2200,7 +2200,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -2847,14 +2847,14 @@ class OrganizationOwner {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/cloudresourcemanager/v2.dart
+++ b/generated/googleapis/lib/cloudresourcemanager/v2.dart
@@ -849,7 +849,7 @@ typedef DeleteTagValueMetadata = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -1140,14 +1140,14 @@ class Operation {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/cloudresourcemanager/v3.dart
+++ b/generated/googleapis/lib/cloudresourcemanager/v3.dart
@@ -2816,7 +2816,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -3459,14 +3459,14 @@ class Organization {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/cloudscheduler/v1.dart
+++ b/generated/googleapis/lib/cloudscheduler/v1.dart
@@ -931,8 +931,8 @@ class Job {
   /// the `n+1`th execution is scheduled to run at 16:00 but the `n`th execution
   /// takes until 16:15, the `n+1`th execution will not start until `16:15`. A
   /// scheduled start time will be delayed if the previous execution has not
-  /// ended when its scheduled time occurs. If retry_count > 0 and a job attempt
-  /// fails, the job will be tried a total of retry_count times, with
+  /// ended when its scheduled time occurs. If retry_count \> 0 and a job
+  /// attempt fails, the job will be tried a total of retry_count times, with
   /// exponential backoff, until the next scheduled start time.
   core.String? schedule;
 

--- a/generated/googleapis/lib/cloudsearch/v1.dart
+++ b/generated/googleapis/lib/cloudsearch/v1.dart
@@ -2758,12 +2758,13 @@ class BooleanOperatorOptions {
   /// boolean property.
   ///
   /// For example, if operatorName is *closed* and the property's name is
-  /// *isClosed*, then queries like *closed:<value>* show results only where the
-  /// value of the property named *isClosed* matches *<value>*. By contrast, a
-  /// search that uses the same *<value>* without an operator returns all items
-  /// where *<value>* matches the value of any String properties or text within
-  /// the content field for the item. The operator name can only contain
-  /// lowercase letters (a-z). The maximum length is 32 characters.
+  /// *isClosed*, then queries like *closed:\<value\>* show results only where
+  /// the value of the property named *isClosed* matches *\<value\>*. By
+  /// contrast, a search that uses the same *\<value\>* without an operator
+  /// returns all items where *\<value\>* matches the value of any String
+  /// properties or text within the content field for the item. The operator
+  /// name can only contain lowercase letters (a-z). The maximum length is 32
+  /// characters.
   core.String? operatorName;
 
   BooleanOperatorOptions({
@@ -3132,8 +3133,8 @@ class DataSource {
   /// A short name or alias for the source.
   ///
   /// This value will be used to match the 'source' operator. For example, if
-  /// the short name is *<value>* then queries like *source:<value>* will only
-  /// return results for this source. The value must be unique across all
+  /// the short name is *\<value\>* then queries like *source:\<value\>* will
+  /// only return results for this source. The value must be unique across all
   /// datasources. The value must only contain alphanumeric characters
   /// (a-zA-Z0-9). The value cannot start with 'google' and cannot be one of the
   /// following: mail, gmail, docs, drive, groups, sites, calendar, hangouts,
@@ -3329,20 +3330,20 @@ class DateOperatorOptions {
   /// date property using the greater-than operator.
   ///
   /// For example, if greaterThanOperatorName is *closedafter* and the
-  /// property's name is *closeDate*, then queries like *closedafter:<value>*
+  /// property's name is *closeDate*, then queries like *closedafter:\<value\>*
   /// show results only where the value of the property named *closeDate* is
-  /// later than *<value>*. The operator name can only contain lowercase letters
-  /// (a-z). The maximum length is 32 characters.
+  /// later than *\<value\>*. The operator name can only contain lowercase
+  /// letters (a-z). The maximum length is 32 characters.
   core.String? greaterThanOperatorName;
 
   /// Indicates the operator name required in the query in order to isolate the
   /// date property using the less-than operator.
   ///
   /// For example, if lessThanOperatorName is *closedbefore* and the property's
-  /// name is *closeDate*, then queries like *closedbefore:<value>* show results
-  /// only where the value of the property named *closeDate* is earlier than
-  /// *<value>*. The operator name can only contain lowercase letters (a-z). The
-  /// maximum length is 32 characters.
+  /// name is *closeDate*, then queries like *closedbefore:\<value\>* show
+  /// results only where the value of the property named *closeDate* is earlier
+  /// than *\<value\>*. The operator name can only contain lowercase letters
+  /// (a-z). The maximum length is 32 characters.
   core.String? lessThanOperatorName;
 
   /// Indicates the actual string required in the query in order to isolate the
@@ -3350,10 +3351,10 @@ class DateOperatorOptions {
   ///
   /// For example, suppose an issue tracking schema object has a property named
   /// *closeDate* that specifies an operator with an operatorName of *closedon*.
-  /// For searches on that data, queries like *closedon:<value>* show results
-  /// only where the value of the *closeDate* property matches *<value>*. By
-  /// contrast, a search that uses the same *<value>* without an operator
-  /// returns all items where *<value>* matches the value of any String
+  /// For searches on that data, queries like *closedon:\<value\>* show results
+  /// only where the value of the *closeDate* property matches *\<value\>*. By
+  /// contrast, a search that uses the same *\<value\>* without an operator
+  /// returns all items where *\<value\>* matches the value of any String
   /// properties or text within the content field for the indexed datasource.
   /// The operator name can only contain lowercase letters (a-z). The maximum
   /// length is 32 characters.
@@ -3739,10 +3740,10 @@ class EnumOperatorOptions {
   /// enum property.
   ///
   /// For example, if operatorName is *priority* and the property's name is
-  /// *priorityVal*, then queries like *priority:<value>* show results only
-  /// where the value of the property named *priorityVal* matches *<value>*. By
-  /// contrast, a search that uses the same *<value>* without an operator
-  /// returns all items where *<value>* matches the value of any String
+  /// *priorityVal*, then queries like *priority:\<value\>* show results only
+  /// where the value of the property named *priorityVal* matches *\<value\>*.
+  /// By contrast, a search that uses the same *\<value\>* without an operator
+  /// returns all items where *\<value\>* matches the value of any String
   /// properties or text within the content field for the item. The operator
   /// name can only contain lowercase letters (a-z). The maximum length is 32
   /// characters.
@@ -4482,12 +4483,13 @@ class HtmlOperatorOptions {
   /// html property.
   ///
   /// For example, if operatorName is *subject* and the property's name is
-  /// *subjectLine*, then queries like *subject:<value>* show results only where
-  /// the value of the property named *subjectLine* matches *<value>*. By
-  /// contrast, a search that uses the same *<value>* without an operator return
-  /// all items where *<value>* matches the value of any html properties or text
-  /// within the content field for the item. The operator name can only contain
-  /// lowercase letters (a-z). The maximum length is 32 characters.
+  /// *subjectLine*, then queries like *subject:\<value\>* show results only
+  /// where the value of the property named *subjectLine* matches *\<value\>*.
+  /// By contrast, a search that uses the same *\<value\>* without an operator
+  /// return all items where *\<value\>* matches the value of any html
+  /// properties or text within the content field for the item. The operator
+  /// name can only contain lowercase letters (a-z). The maximum length is 32
+  /// characters.
   core.String? operatorName;
 
   HtmlOperatorOptions({
@@ -4663,18 +4665,19 @@ class IntegerOperatorOptions {
   ///
   /// For example, if greaterThanOperatorName is *priorityabove* and the
   /// property's name is *priorityVal*, then queries like
-  /// *priorityabove:<value>* show results only where the value of the property
-  /// named *priorityVal* is greater than *<value>*. The operator name can only
-  /// contain lowercase letters (a-z). The maximum length is 32 characters.
+  /// *priorityabove:\<value\>* show results only where the value of the
+  /// property named *priorityVal* is greater than *\<value\>*. The operator
+  /// name can only contain lowercase letters (a-z). The maximum length is 32
+  /// characters.
   core.String? greaterThanOperatorName;
 
   /// Indicates the operator name required in the query in order to isolate the
   /// integer property using the less-than operator.
   ///
   /// For example, if lessThanOperatorName is *prioritybelow* and the property's
-  /// name is *priorityVal*, then queries like *prioritybelow:<value>* show
+  /// name is *priorityVal*, then queries like *prioritybelow:\<value\>* show
   /// results only where the value of the property named *priorityVal* is less
-  /// than *<value>*. The operator name can only contain lowercase letters
+  /// than *\<value\>*. The operator name can only contain lowercase letters
   /// (a-z). The maximum length is 32 characters.
   core.String? lessThanOperatorName;
 
@@ -4682,10 +4685,10 @@ class IntegerOperatorOptions {
   /// integer property.
   ///
   /// For example, if operatorName is *priority* and the property's name is
-  /// *priorityVal*, then queries like *priority:<value>* show results only
-  /// where the value of the property named *priorityVal* matches *<value>*. By
-  /// contrast, a search that uses the same *<value>* without an operator
-  /// returns all items where *<value>* matches the value of any String
+  /// *priorityVal*, then queries like *priority:\<value\>* show results only
+  /// where the value of the property named *priorityVal* matches *\<value\>*.
+  /// By contrast, a search that uses the same *\<value\>* without an operator
+  /// returns all items where *\<value\>* matches the value of any String
   /// properties or text within the content field for the item. The operator
   /// name can only contain lowercase letters (a-z). The maximum length is 32
   /// characters.
@@ -8779,12 +8782,13 @@ class TextOperatorOptions {
   /// text property.
   ///
   /// For example, if operatorName is *subject* and the property's name is
-  /// *subjectLine*, then queries like *subject:<value>* show results only where
-  /// the value of the property named *subjectLine* matches *<value>*. By
-  /// contrast, a search that uses the same *<value>* without an operator
-  /// returns all items where *<value>* matches the value of any text properties
-  /// or text within the content field for the item. The operator name can only
-  /// contain lowercase letters (a-z). The maximum length is 32 characters.
+  /// *subjectLine*, then queries like *subject:\<value\>* show results only
+  /// where the value of the property named *subjectLine* matches *\<value\>*.
+  /// By contrast, a search that uses the same *\<value\>* without an operator
+  /// returns all items where *\<value\>* matches the value of any text
+  /// properties or text within the content field for the item. The operator
+  /// name can only contain lowercase letters (a-z). The maximum length is 32
+  /// characters.
   core.String? operatorName;
 
   TextOperatorOptions({
@@ -8874,30 +8878,30 @@ class TimestampOperatorOptions {
   /// timestamp property using the greater-than operator.
   ///
   /// For example, if greaterThanOperatorName is *closedafter* and the
-  /// property's name is *closeDate*, then queries like *closedafter:<value>*
+  /// property's name is *closeDate*, then queries like *closedafter:\<value\>*
   /// show results only where the value of the property named *closeDate* is
-  /// later than *<value>*. The operator name can only contain lowercase letters
-  /// (a-z). The maximum length is 32 characters.
+  /// later than *\<value\>*. The operator name can only contain lowercase
+  /// letters (a-z). The maximum length is 32 characters.
   core.String? greaterThanOperatorName;
 
   /// Indicates the operator name required in the query in order to isolate the
   /// timestamp property using the less-than operator.
   ///
   /// For example, if lessThanOperatorName is *closedbefore* and the property's
-  /// name is *closeDate*, then queries like *closedbefore:<value>* show results
-  /// only where the value of the property named *closeDate* is earlier than
-  /// *<value>*. The operator name can only contain lowercase letters (a-z). The
-  /// maximum length is 32 characters.
+  /// name is *closeDate*, then queries like *closedbefore:\<value\>* show
+  /// results only where the value of the property named *closeDate* is earlier
+  /// than *\<value\>*. The operator name can only contain lowercase letters
+  /// (a-z). The maximum length is 32 characters.
   core.String? lessThanOperatorName;
 
   /// Indicates the operator name required in the query in order to isolate the
   /// timestamp property.
   ///
   /// For example, if operatorName is *closedon* and the property's name is
-  /// *closeDate*, then queries like *closedon:<value>* show results only where
-  /// the value of the property named *closeDate* matches *<value>*. By
-  /// contrast, a search that uses the same *<value>* without an operator
-  /// returns all items where *<value>* matches the value of any String
+  /// *closeDate*, then queries like *closedon:\<value\>* show results only
+  /// where the value of the property named *closeDate* matches *\<value\>*. By
+  /// contrast, a search that uses the same *\<value\>* without an operator
+  /// returns all items where *\<value\>* matches the value of any String
   /// properties or text within the content field for the item. The operator
   /// name can only contain lowercase letters (a-z). The maximum length is 32
   /// characters.

--- a/generated/googleapis/lib/cloudshell/v1.dart
+++ b/generated/googleapis/lib/cloudshell/v1.dart
@@ -500,7 +500,7 @@ class AddPublicKeyRequest {
   /// Supported formats are `ssh-dss` (see RFC4253), `ssh-rsa` (see RFC4253),
   /// `ecdsa-sha2-nistp256` (see RFC5656), `ecdsa-sha2-nistp384` (see RFC5656)
   /// and `ecdsa-sha2-nistp521` (see RFC5656). It should be structured as
-  /// <format> <content>, where <content> part is encoded with Base64.
+  /// \<format\> \<content\>, where \<content\> part is encoded with Base64.
   core.String? key;
 
   AddPublicKeyRequest({

--- a/generated/googleapis/lib/cloudtasks/v2.dart
+++ b/generated/googleapis/lib/cloudtasks/v2.dart
@@ -1476,7 +1476,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -1868,14 +1868,14 @@ typedef PauseQueueRequest = $Empty;
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {
@@ -2196,7 +2196,7 @@ class RetryConfig {
   ///
   /// Cloud Tasks will attempt the task `max_attempts` times (that is, if the
   /// first attempt fails, then there will be `max_attempts - 1` retries). Must
-  /// be >= -1. If unspecified when the queue is created, Cloud Tasks will pick
+  /// be \>= -1. If unspecified when the queue is created, Cloud Tasks will pick
   /// the default. -1 indicates unlimited attempts. This field has the same
   /// meaning as
   /// [task_retry_limit in queue.yaml/xml](https://cloud.google.com/appengine/docs/standard/python/config/queueref#retry_parameters).

--- a/generated/googleapis/lib/composer/v1.dart
+++ b/generated/googleapis/lib/composer/v1.dart
@@ -794,7 +794,7 @@ class Environment {
   /// map are UTF8 strings that comply with the following restrictions: * Keys
   /// must conform to regexp: \p{Ll}\p{Lo}{0,62} * Values must conform to
   /// regexp: \[\p{Ll}\p{Lo}\p{N}_-\]{0,63} * Both keys and values are
-  /// additionally constrained to be <= 128 bytes in size.
+  /// additionally constrained to be \<= 128 bytes in size.
   ///
   /// Optional.
   core.Map<core.String, core.String>? labels;
@@ -1835,7 +1835,7 @@ class SoftwareConfig {
   ///
   /// Keys refer to the lowercase package name such as "numpy" and values are
   /// the lowercase extras and version specifier such as "==1.12.0",
-  /// "\[devel,gcp_api\]", or "\[devel\]>=1.8.2, <1.9.2". To specify a package
+  /// "\[devel,gcp_api\]", or "\[devel\]\>=1.8.2, \<1.9.2". To specify a package
   /// without pinning it to a version specifier, use the empty string as the
   /// value.
   ///

--- a/generated/googleapis/lib/compute/v1.dart
+++ b/generated/googleapis/lib/compute/v1.dart
@@ -51934,7 +51934,7 @@ class ExchangedPeeringRoutesList {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -58042,7 +58042,7 @@ class HttpRedirectAction {
 class HttpRetryPolicy {
   /// Specifies the allowed number retries.
   ///
-  /// This number must be > 0. If not specified, defaults to 1.
+  /// This number must be \> 0. If not specified, defaults to 1.
   core.int? numRetries;
 
   /// Specifies a non-zero timeout per retry attempt.
@@ -69833,7 +69833,7 @@ class MetadataFilterLabelMatch {
 
 /// The named port.
 ///
-/// For example: <"http", 80>.
+/// For example: \<"http", 80\>.
 class NamedPort {
   /// The name for this named port.
   ///
@@ -78042,14 +78042,14 @@ class PerInstanceConfig {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/connectors/v1.dart
+++ b/generated/googleapis/lib/connectors/v1.dart
@@ -2438,7 +2438,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -3285,14 +3285,14 @@ typedef OperationMetadata = $OperationMetadata00;
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/container/v1.dart
+++ b/generated/googleapis/lib/container/v1.dart
@@ -7631,13 +7631,13 @@ class NodePoolAutoscaling {
 
   /// Maximum number of nodes for one location in the NodePool.
   ///
-  /// Must be >= min_node_count. There has to be enough quota to scale up the
+  /// Must be \>= min_node_count. There has to be enough quota to scale up the
   /// cluster.
   core.int? maxNodeCount;
 
   /// Minimum number of nodes for one location in the NodePool.
   ///
-  /// Must be >= 1 and <= max_node_count.
+  /// Must be \>= 1 and \<= max_node_count.
   core.int? minNodeCount;
 
   NodePoolAutoscaling({

--- a/generated/googleapis/lib/content/v2_1.dart
+++ b/generated/googleapis/lib/content/v2_1.dart
@@ -12421,7 +12421,7 @@ class Headers {
   /// A list of inclusive number of items upper bounds.
   ///
   /// The last value can be `"infinity"`. For example `["10", "50", "infinity"]`
-  /// represents the headers "<= 10 items", "<= 50 items", and "> 50 items".
+  /// represents the headers "\<= 10 items", "\<= 50 items", and "\> 50 items".
   /// Must be non-empty. Can only be set if all other fields are not set.
   core.List<core.String>? numberOfItems;
 
@@ -12437,8 +12437,8 @@ class Headers {
   ///
   /// The last price's value can be `"infinity"`. For example `[{"value": "10",
   /// "currency": "USD"}, {"value": "500", "currency": "USD"}, {"value":
-  /// "infinity", "currency": "USD"}]` represents the headers "<= $10", "<=
-  /// $500", and "> $500". All prices within a service must have the same
+  /// "infinity", "currency": "USD"}]` represents the headers "\<= $10", "\<=
+  /// $500", and "\> $500". All prices within a service must have the same
   /// currency. Must be non-empty. Can only be set if all other fields are not
   /// set.
   core.List<Price>? prices;
@@ -12447,9 +12447,9 @@ class Headers {
   ///
   /// The last weight's value can be `"infinity"`. For example `[{"value": "10",
   /// "unit": "kg"}, {"value": "50", "unit": "kg"}, {"value": "infinity",
-  /// "unit": "kg"}]` represents the headers "<= 10kg", "<= 50kg", and "> 50kg".
-  /// All weights within a service must have the same unit. Must be non-empty.
-  /// Can only be set if all other fields are not set.
+  /// "unit": "kg"}]` represents the headers "\<= 10kg", "\<= 50kg", and "\>
+  /// 50kg". All weights within a service must have the same unit. Must be
+  /// non-empty. Can only be set if all other fields are not set.
   core.List<Weight>? weights;
 
   Headers({
@@ -12664,9 +12664,9 @@ class InapplicabilityDetails {
   /// price in the restriction.
   /// - "UNCATEGORIZED" : The reason is not categorized to any known reason.
   /// - "INVALID_AUTO_PRICE_MIN" : The auto_pricing_min_price is invalid. For
-  /// example, it is missing or < 0.
+  /// example, it is missing or \< 0.
   /// - "INVALID_FLOOR_CONFIG" : The floor defined in the rule is invalid. For
-  /// example, it has the wrong sign which results in a floor < 0.
+  /// example, it has the wrong sign which results in a floor \< 0.
   core.String? inapplicableReason;
 
   InapplicabilityDetails({
@@ -24612,7 +24612,7 @@ class RepricingRuleReportBuyboxWinningRuleStats {
 class RepricingRuleRestriction {
   /// The inclusive floor lower bound.
   ///
-  /// The repricing rule only applies when new price >= floor.
+  /// The repricing rule only applies when new price \>= floor.
   RepricingRuleRestrictionBoundary? floor;
 
   /// If true, use the AUTO_PRICING_MIN_PRICE offer attribute as the lower bound
@@ -24652,16 +24652,16 @@ class RepricingRuleRestrictionBoundary {
   /// The percentage delta relative to the offer selling price.
   ///
   /// This field is signed. It must be negative in floor. When it is used in
-  /// floor, it should be > -100. For example, if an offer is selling at $10 and
-  /// this field is -30 in floor, the repricing rule only applies if the
-  /// calculated new price is >= $7.
+  /// floor, it should be \> -100. For example, if an offer is selling at $10
+  /// and this field is -30 in floor, the repricing rule only applies if the
+  /// calculated new price is \>= $7.
   core.int? percentageDelta;
 
   /// The price micros relative to the offer selling price.
   ///
   /// This field is signed. It must be negative in floor. For example, if an
   /// offer is selling at $10 and this field is -$2 in floor, the repricing rule
-  /// only applies if the calculated new price is >= $8.
+  /// only applies if the calculated new price is \>= $8.
   core.String? priceDelta;
 
   RepricingRuleRestrictionBoundary({

--- a/generated/googleapis/lib/datacatalog/v1.dart
+++ b/generated/googleapis/lib/datacatalog/v1.dart
@@ -2991,7 +2991,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -5725,14 +5725,14 @@ class GoogleCloudDatacatalogV1ViewSpec {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/datafusion/v1.dart
+++ b/generated/googleapis/lib/datafusion/v1.dart
@@ -1091,7 +1091,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -1795,14 +1795,14 @@ class OperationMetadata {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') - etag: BwWWja0YfJA= -
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') - etag: BwWWja0YfJA= -
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/datamigration/v1.dart
+++ b/generated/googleapis/lib/datamigration/v1.dart
@@ -383,11 +383,12 @@ class ProjectsLocationsConnectionProfilesResource {
   /// the response. The expression must specify the field name, a comparison
   /// operator, and the value that you want to use for filtering. The value must
   /// be a string, a number, or a boolean. The comparison operator must be
-  /// either =, !=, >, or <. For example, list connection profiles created this
-  /// year by specifying **createTime %gt; 2020-01-01T00:00:00.000000000Z**. You
-  /// can also filter nested fields. For example, you could specify
-  /// **mySql.username = %lt;my_username%gt;** to list all connection profiles
-  /// configured to connect with a specific username.
+  /// either =, !=, \>, or \<. For example, list connection profiles created
+  /// this year by specifying **createTime %gt;
+  /// 2020-01-01T00:00:00.000000000Z**. You can also filter nested fields. For
+  /// example, you could specify **mySql.username = %lt;my_username%gt;** to
+  /// list all connection profiles configured to connect with a specific
+  /// username.
   ///
   /// [orderBy] - the order by fields for the result.
   ///
@@ -844,9 +845,9 @@ class ProjectsLocationsMigrationJobsResource {
   /// response. The expression must specify the field name, a comparison
   /// operator, and the value that you want to use for filtering. The value must
   /// be a string, a number, or a boolean. The comparison operator must be
-  /// either =, !=, >, or <. For example, list migration jobs created this year
-  /// by specifying **createTime %gt; 2020-01-01T00:00:00.000000000Z.** You can
-  /// also filter nested fields. For example, you could specify
+  /// either =, !=, \>, or \<. For example, list migration jobs created this
+  /// year by specifying **createTime %gt; 2020-01-01T00:00:00.000000000Z.** You
+  /// can also filter nested fields. For example, you could specify
   /// **reverseSshConnectivity.vmIp = "1.2.3.4"** to select all migration jobs
   /// connecting through the specific SSH tunnel bastion.
   ///
@@ -2079,7 +2080,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -2800,14 +2801,14 @@ class Operation {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/dataproc/v1.dart
+++ b/generated/googleapis/lib/dataproc/v1.dart
@@ -4920,7 +4920,7 @@ class EndpointConfig {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec.Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -5669,7 +5669,7 @@ class InstanceGroupConfig {
 
   /// Specifies the minimum cpu platform for the Instance Group.
   ///
-  /// See Dataproc -> Minimum CPU Platform
+  /// See Dataproc -\> Minimum CPU Platform
   /// (https://cloud.google.com/dataproc/docs/concepts/compute/dataproc-min-cpu).
   ///
   /// Optional.
@@ -7508,14 +7508,14 @@ class PigJob {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } YAML example: bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the IAM
 /// documentation (https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/datastore/v1.dart
+++ b/generated/googleapis/lib/datastore/v1.dart
@@ -1766,9 +1766,9 @@ class GoogleDatastoreAdminV1IndexedProperty {
   /// Possible string values are:
   /// - "DIRECTION_UNSPECIFIED" : The direction is unspecified.
   /// - "ASCENDING" : The property's values are indexed so as to support
-  /// sequencing in ascending order and also query by <, >, <=, >=, and =.
+  /// sequencing in ascending order and also query by \<, \>, \<=, \>=, and =.
   /// - "DESCENDING" : The property's values are indexed so as to support
-  /// sequencing in descending order and also query by <, >, <=, >=, and =.
+  /// sequencing in descending order and also query by \<, \>, \<=, \>=, and =.
   core.String? direction;
 
   /// The property name to index.
@@ -2744,13 +2744,13 @@ class Query {
   /// The maximum number of results to return.
   ///
   /// Applies after all other constraints. Optional. Unspecified is interpreted
-  /// as no limit. Must be >= 0 if specified.
+  /// as no limit. Must be \>= 0 if specified.
   core.int? limit;
 
   /// The number of results to skip.
   ///
   /// Applies before limit, but after all other constraints. Optional. Must be
-  /// >= 0 if specified.
+  /// \>= 0 if specified.
   core.int? offset;
 
   /// The order to apply to the query results (if empty, order is unspecified).

--- a/generated/googleapis/lib/deploymentmanager/v2.dart
+++ b/generated/googleapis/lib/deploymentmanager/v2.dart
@@ -1748,7 +1748,7 @@ class DeploymentsStopRequest {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -2545,14 +2545,14 @@ class OperationsListResponse {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/dfareporting/v3_4.dart
+++ b/generated/googleapis/lib/dfareporting/v3_4.dart
@@ -11534,7 +11534,7 @@ class AccountUserProfile {
   ///
   /// This is a required field. Must be less than 64 characters long, must be
   /// globally unique, and cannot contain whitespace or any of the following
-  /// characters: "&;<>"#%,".
+  /// characters: "&;\<\>"#%,".
   core.String? name;
 
   /// Filter that describes which sites are visible to the user profile.

--- a/generated/googleapis/lib/dfareporting/v3_5.dart
+++ b/generated/googleapis/lib/dfareporting/v3_5.dart
@@ -11539,7 +11539,7 @@ class AccountUserProfile {
   ///
   /// This is a required field. Must be less than 64 characters long, must be
   /// globally unique, and cannot contain whitespace or any of the following
-  /// characters: "&;<>"#%,".
+  /// characters: "&;\<\>"#%,".
   core.String? name;
 
   /// Filter that describes which sites are visible to the user profile.

--- a/generated/googleapis/lib/dialogflow/v2.dart
+++ b/generated/googleapis/lib/dialogflow/v2.dart
@@ -11999,8 +11999,8 @@ class GoogleCloudDialogflowCxV3Page {
   ///
   /// Transition route groups must be unique within a page. * If multiple
   /// transition routes within a page scope refer to the same intent, then the
-  /// precedence order is: page's transition route -> page's transition route
-  /// group -> flow's transition routes. * If multiple transition route groups
+  /// precedence order is: page's transition route -\> page's transition route
+  /// group -\> flow's transition routes. * If multiple transition route groups
   /// within a page contain the same intent, then the first group in the ordered
   /// list takes precedence.
   /// Format:`projects//locations//agents//flows//transitionRouteGroups/`.
@@ -14565,8 +14565,8 @@ class GoogleCloudDialogflowCxV3beta1Page {
   ///
   /// Transition route groups must be unique within a page. * If multiple
   /// transition routes within a page scope refer to the same intent, then the
-  /// precedence order is: page's transition route -> page's transition route
-  /// group -> flow's transition routes. * If multiple transition route groups
+  /// precedence order is: page's transition route -\> page's transition route
+  /// group -\> flow's transition routes. * If multiple transition route groups
   /// within a page contain the same intent, then the first group in the ordered
   /// list takes precedence.
   /// Format:`projects//locations//agents//flows//transitionRouteGroups/`.
@@ -22402,7 +22402,7 @@ class GoogleCloudDialogflowV2SynthesizeSpeechConfig {
   ///
   /// 1.0 is the normal native speed supported by the specific voice. 2.0 is
   /// twice as fast, and 0.5 is half as fast. If unset(0.0), defaults to the
-  /// native 1.0 speed. Any other values < 0.25 or > 4.0 will return an error.
+  /// native 1.0 speed. Any other values \< 0.25 or \> 4.0 will return an error.
   ///
   /// Optional.
   core.double? speakingRate;

--- a/generated/googleapis/lib/dialogflow/v3.dart
+++ b/generated/googleapis/lib/dialogflow/v3.dart
@@ -4838,7 +4838,7 @@ class ProjectsLocationsAgentsTestCasesResultsResource {
   /// "environment=draft AND latest" matches the latest test result for each
   /// test case in the draft environment. * "environment IN (e1,e2)" matches any
   /// test case results with an environment resource name of either "e1" or
-  /// "e2". * "test_time > 1602540713" matches any test case results with test
+  /// "e2". * "test_time \> 1602540713" matches any test case results with test
   /// time later than a unix timestamp in seconds 1602540713.
   ///
   /// [pageSize] - The maximum number of items to return in a single page. By
@@ -5639,7 +5639,7 @@ class ProjectsOperationsResource {
 /// Hierarchical advanced settings for agent/flow/page/fulfillment/parameter.
 ///
 /// Settings exposed at lower level overrides the settings exposed at higher
-/// level. Hierarchy: Agent->Flow->Page->Fulfillment/Parameter.
+/// level. Hierarchy: Agent-\>Flow-\>Page-\>Fulfillment/Parameter.
 class GoogleCloudDialogflowCxV3AdvancedSettings {
   /// Settings for logging.
   ///
@@ -7125,9 +7125,9 @@ class GoogleCloudDialogflowCxV3Experiment {
 
   /// The current state of the experiment.
   ///
-  /// Transition triggered by Experiments.StartExperiment: DRAFT->RUNNING.
-  /// Transition triggered by Experiments.CancelExperiment: DRAFT->DONE or
-  /// RUNNING->DONE.
+  /// Transition triggered by Experiments.StartExperiment: DRAFT-\>RUNNING.
+  /// Transition triggered by Experiments.CancelExperiment: DRAFT-\>DONE or
+  /// RUNNING-\>DONE.
   /// Possible string values are:
   /// - "STATE_UNSPECIFIED" : State unspecified.
   /// - "DRAFT" : The experiment is created but not started yet.
@@ -9738,8 +9738,8 @@ class GoogleCloudDialogflowCxV3Page {
   ///
   /// Transition route groups must be unique within a page. * If multiple
   /// transition routes within a page scope refer to the same intent, then the
-  /// precedence order is: page's transition route -> page's transition route
-  /// group -> flow's transition routes. * If multiple transition route groups
+  /// precedence order is: page's transition route -\> page's transition route
+  /// group -\> flow's transition routes. * If multiple transition route groups
   /// within a page contain the same intent, then the first group in the ordered
   /// list takes precedence.
   /// Format:`projects//locations//agents//flows//transitionRouteGroups/`.
@@ -10650,16 +10650,16 @@ class GoogleCloudDialogflowCxV3RestoreAgentRequest {
 class GoogleCloudDialogflowCxV3RolloutConfig {
   /// The conditions that are used to evaluate the failure of a rollout step.
   ///
-  /// If not specified, no rollout steps will fail. E.g. "containment_rate < 10%
-  /// OR average_turn_count < 3". See the
+  /// If not specified, no rollout steps will fail. E.g. "containment_rate \<
+  /// 10% OR average_turn_count \< 3". See the
   /// [conditions reference](https://cloud.google.com/dialogflow/cx/docs/reference/condition).
   core.String? failureCondition;
 
   /// The conditions that are used to evaluate the success of a rollout step.
   ///
   /// If not specified, all rollout steps will proceed to the next one unless
-  /// failure conditions are met. E.g. "containment_rate > 60% AND callback_rate
-  /// < 20%". See the
+  /// failure conditions are met. E.g. "containment_rate \> 60% AND
+  /// callback_rate \< 20%". See the
   /// [conditions reference](https://cloud.google.com/dialogflow/cx/docs/reference/condition).
   core.String? rolloutCondition;
 
@@ -11180,7 +11180,7 @@ class GoogleCloudDialogflowCxV3SynthesizeSpeechConfig {
   ///
   /// 1.0 is the normal native speed supported by the specific voice. 2.0 is
   /// twice as fast, and 0.5 is half as fast. If unset(0.0), defaults to the
-  /// native 1.0 speed. Any other values < 0.25 or > 4.0 will return an error.
+  /// native 1.0 speed. Any other values \< 0.25 or \> 4.0 will return an error.
   ///
   /// Optional.
   core.double? speakingRate;
@@ -14074,8 +14074,8 @@ class GoogleCloudDialogflowCxV3beta1Page {
   ///
   /// Transition route groups must be unique within a page. * If multiple
   /// transition routes within a page scope refer to the same intent, then the
-  /// precedence order is: page's transition route -> page's transition route
-  /// group -> flow's transition routes. * If multiple transition route groups
+  /// precedence order is: page's transition route -\> page's transition route
+  /// group -\> flow's transition routes. * If multiple transition route groups
   /// within a page contain the same intent, then the first group in the ordered
   /// list takes precedence.
   /// Format:`projects//locations//agents//flows//transitionRouteGroups/`.

--- a/generated/googleapis/lib/displayvideo/v1.dart
+++ b/generated/googleapis/lib/displayvideo/v1.dart
@@ -2439,7 +2439,7 @@ class AdvertisersInsertionOrdersResource {
   /// Restrictions can be combined by `AND` or `OR` logical operators. A
   /// sequence of restrictions implicitly uses `AND`. * A restriction has the
   /// form of `{field} {operator} {value}`. * The operator used on
-  /// `budget.budget_segments.date_range.end_date` must be LESS THAN (<). * The
+  /// `budget.budget_segments.date_range.end_date` must be LESS THAN (\<). * The
   /// operator used on `updateTime` must be `GREATER THAN OR EQUAL TO (>=)` or
   /// `LESS THAN OR EQUAL TO (<=)`. * The operators used on all other fields
   /// must be `EQUALS (=)`. * Supported fields: - `campaignId` - `displayName` -
@@ -3383,7 +3383,7 @@ class AdvertisersLineItemsResource {
   /// can be combined by `AND` or `OR` logical operators. A sequence of
   /// restrictions implicitly uses `AND`. * A restriction has the form of
   /// `{field} {operator} {value}`. * The operator used on
-  /// `flight.dateRange.endDate` must be LESS THAN (<). * The operator used on
+  /// `flight.dateRange.endDate` must be LESS THAN (\<). * The operator used on
   /// `updateTime` must be `GREATER THAN OR EQUAL TO (>=)` or `LESS THAN OR
   /// EQUAL TO (<=)`. * The operator used on `warningMessages` must be `HAS
   /// (:)`. * The operators used on all other fields must be `EQUALS (=)`. *
@@ -16324,13 +16324,13 @@ class DoubleVerifyAppStarRating {
   /// Possible string values are:
   /// - "APP_STAR_RATE_UNSPECIFIED" : This enum is only a placeholder and it
   /// doesn't specify any app star rating options.
-  /// - "APP_STAR_RATE_1_POINT_5_LESS" : Official Apps with rating < 1.5 Stars.
-  /// - "APP_STAR_RATE_2_LESS" : Official Apps with rating < 2 Stars.
-  /// - "APP_STAR_RATE_2_POINT_5_LESS" : Official Apps with rating < 2.5 Stars.
-  /// - "APP_STAR_RATE_3_LESS" : Official Apps with rating < 3 Stars.
-  /// - "APP_STAR_RATE_3_POINT_5_LESS" : Official Apps with rating < 3.5 Stars.
-  /// - "APP_STAR_RATE_4_LESS" : Official Apps with rating < 4 Stars.
-  /// - "APP_STAR_RATE_4_POINT_5_LESS" : Official Apps with rating < 4.5 Stars.
+  /// - "APP_STAR_RATE_1_POINT_5_LESS" : Official Apps with rating \< 1.5 Stars.
+  /// - "APP_STAR_RATE_2_LESS" : Official Apps with rating \< 2 Stars.
+  /// - "APP_STAR_RATE_2_POINT_5_LESS" : Official Apps with rating \< 2.5 Stars.
+  /// - "APP_STAR_RATE_3_LESS" : Official Apps with rating \< 3 Stars.
+  /// - "APP_STAR_RATE_3_POINT_5_LESS" : Official Apps with rating \< 3.5 Stars.
+  /// - "APP_STAR_RATE_4_LESS" : Official Apps with rating \< 4 Stars.
+  /// - "APP_STAR_RATE_4_POINT_5_LESS" : Official Apps with rating \< 4.5 Stars.
   core.String? avoidedStarRating;
 
   DoubleVerifyAppStarRating({

--- a/generated/googleapis/lib/dlp/v2.dart
+++ b/generated/googleapis/lib/dlp/v2.dart
@@ -1117,7 +1117,7 @@ class OrganizationsLocationsDlpJobsResource {
   /// operator must be `=` or `!=`. Examples: * inspected_storage =
   /// cloud_storage AND state = done * inspected_storage = cloud_storage OR
   /// inspected_storage = bigquery * inspected_storage = cloud_storage AND
-  /// (state = done OR state = canceled) * end_time >
+  /// (state = done OR state = canceled) * end_time \>
   /// \"2017-12-12T00:00:00+00:00\" The length of this field should be no more
   /// than 500 characters.
   ///
@@ -1622,7 +1622,7 @@ class OrganizationsLocationsJobTriggersResource {
   /// Examples: * inspected_storage = cloud_storage AND status = HEALTHY *
   /// inspected_storage = cloud_storage OR inspected_storage = bigquery *
   /// inspected_storage = cloud_storage AND (state = PAUSED OR state = HEALTHY)
-  /// * last_run_time > \"2017-12-12T00:00:00+00:00\" The length of this field
+  /// * last_run_time \> \"2017-12-12T00:00:00+00:00\" The length of this field
   /// should be no more than 500 characters.
   ///
   /// [locationId] - Deprecated. This field has no effect.
@@ -2968,7 +2968,7 @@ class ProjectsDlpJobsResource {
   /// operator must be `=` or `!=`. Examples: * inspected_storage =
   /// cloud_storage AND state = done * inspected_storage = cloud_storage OR
   /// inspected_storage = bigquery * inspected_storage = cloud_storage AND
-  /// (state = done OR state = canceled) * end_time >
+  /// (state = done OR state = canceled) * end_time \>
   /// \"2017-12-12T00:00:00+00:00\" The length of this field should be no more
   /// than 500 characters.
   ///
@@ -3576,7 +3576,7 @@ class ProjectsJobTriggersResource {
   /// Examples: * inspected_storage = cloud_storage AND status = HEALTHY *
   /// inspected_storage = cloud_storage OR inspected_storage = bigquery *
   /// inspected_storage = cloud_storage AND (state = PAUSED OR state = HEALTHY)
-  /// * last_run_time > \"2017-12-12T00:00:00+00:00\" The length of this field
+  /// * last_run_time \> \"2017-12-12T00:00:00+00:00\" The length of this field
   /// should be no more than 500 characters.
   ///
   /// [locationId] - Deprecated. This field has no effect.
@@ -4476,7 +4476,7 @@ class ProjectsLocationsDlpJobsResource {
   /// operator must be `=` or `!=`. Examples: * inspected_storage =
   /// cloud_storage AND state = done * inspected_storage = cloud_storage OR
   /// inspected_storage = bigquery * inspected_storage = cloud_storage AND
-  /// (state = done OR state = canceled) * end_time >
+  /// (state = done OR state = canceled) * end_time \>
   /// \"2017-12-12T00:00:00+00:00\" The length of this field should be no more
   /// than 500 characters.
   ///
@@ -5137,7 +5137,7 @@ class ProjectsLocationsJobTriggersResource {
   /// Examples: * inspected_storage = cloud_storage AND status = HEALTHY *
   /// inspected_storage = cloud_storage OR inspected_storage = bigquery *
   /// inspected_storage = cloud_storage AND (state = PAUSED OR state = HEALTHY)
-  /// * last_run_time > \"2017-12-12T00:00:00+00:00\" The length of this field
+  /// * last_run_time \> \"2017-12-12T00:00:00+00:00\" The length of this field
   /// should be no more than 500 characters.
   ///
   /// [locationId] - Deprecated. This field has no effect.
@@ -6339,8 +6339,8 @@ class GooglePrivacyDlpV2Bucket {
 /// Generalization function that buckets values based on ranges.
 ///
 /// The ranges and replacement values are dynamically provided by the user for
-/// custom behavior, such as 1-30 -> LOW 31-65 -> MEDIUM 66-100 -> HIGH This can
-/// be used on data of type: number, long, string, timestamp. If the bound
+/// custom behavior, such as 1-30 -\> LOW 31-65 -\> MEDIUM 66-100 -\> HIGH This
+/// can be used on data of type: number, long, string, timestamp. If the bound
 /// `Value` type differs from the type of data being transformed, we will first
 /// attempt converting the type of the data to be transformed to match the type
 /// of the bound before comparing. See
@@ -6627,7 +6627,7 @@ class GooglePrivacyDlpV2CharsToIgnore {
   /// - "ALPHA_UPPER_CASE" : A-Z
   /// - "ALPHA_LOWER_CASE" : a-z
   /// - "PUNCTUATION" : US Punctuation, one of
-  /// !"#$%&'()*+,-./:;<=>?@\[\]^_\`{|}~
+  /// !"#$%&'()*+,-./:;\<=\>?@\[\]^_\`{|}~
   /// - "WHITESPACE" : Whitespace character, one of \[ \t\n\x0B\f\r\]
   core.String? commonCharactersToIgnore;
 
@@ -7664,7 +7664,7 @@ class GooglePrivacyDlpV2CryptoReplaceFfxFpeConfig {
   /// 95\]. This must be encoded as ASCII. The order of characters does not
   /// matter. The full list of allowed characters is:
   /// 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz
-  /// ~\`!@#$%^&*()_-+={\[}\]|\:;"'<,>.?/
+  /// ~\`!@#$%^&*()_-+={\[}\]|\:;"'\<,\>.?/
   core.String? customAlphabet;
 
   /// The native way to select the alphabet.

--- a/generated/googleapis/lib/documentai/v1.dart
+++ b/generated/googleapis/lib/documentai/v1.dart
@@ -9445,7 +9445,7 @@ typedef GoogleRpcStatus = $Status;
 /// toProto(UIColor* color) { CGFloat red, green, blue, alpha; if (!\[color
 /// getRed:&red green:&green blue:&blue alpha:&alpha\]) { return nil; } Color*
 /// result = \[\[Color alloc\] init\]; \[result setRed:red\]; \[result
-/// setGreen:green\]; \[result setBlue:blue\]; if (alpha <= 0.9999) { \[result
+/// setGreen:green\]; \[result setBlue:blue\]; if (alpha \<= 0.9999) { \[result
 /// setAlpha:floatWrapperWithValue(alpha)\]; } \[result autorelease\]; return
 /// result; } // ... Example (JavaScript): // ... var protoToCssColor =
 /// function(rgb_color) { var redFrac = rgb_color.red || 0.0; var greenFrac =
@@ -9455,10 +9455,10 @@ typedef GoogleRpcStatus = $Status;
 /// rgbToCssColor(red, green, blue); } var alphaFrac = rgb_color.alpha.value ||
 /// 0.0; var rgbParams = \[red, green, blue\].join(','); return \['rgba(',
 /// rgbParams, ',', alphaFrac, ')'\].join(''); }; var rgbToCssColor =
-/// function(red, green, blue) { var rgbNumber = new Number((red << 16) | (green
-/// << 8) | blue); var hexString = rgbNumber.toString(16); var missingZeros = 6
-/// - hexString.length; var resultBuilder = \['#'\]; for (var i = 0; i <
-/// missingZeros; i++) { resultBuilder.push('0'); }
+/// function(red, green, blue) { var rgbNumber = new Number((red \<\< 16) |
+/// (green \<\< 8) | blue); var hexString = rgbNumber.toString(16); var
+/// missingZeros = 6 - hexString.length; var resultBuilder = \['#'\]; for (var i
+/// = 0; i \< missingZeros; i++) { resultBuilder.push('0'); }
 /// resultBuilder.push(hexString); return resultBuilder.join(''); }; // ...
 typedef GoogleTypeColor = $Color;
 

--- a/generated/googleapis/lib/eventarc/v1.dart
+++ b/generated/googleapis/lib/eventarc/v1.dart
@@ -1182,7 +1182,7 @@ class EventFilter {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -1419,14 +1419,14 @@ typedef OperationMetadata = $OperationMetadata00;
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/fcm/v1.dart
+++ b/generated/googleapis/lib/fcm/v1.dart
@@ -719,7 +719,7 @@ class ApnsFcmOptions {
 /// toProto(UIColor* color) { CGFloat red, green, blue, alpha; if (!\[color
 /// getRed:&red green:&green blue:&blue alpha:&alpha\]) { return nil; } Color*
 /// result = \[\[Color alloc\] init\]; \[result setRed:red\]; \[result
-/// setGreen:green\]; \[result setBlue:blue\]; if (alpha <= 0.9999) { \[result
+/// setGreen:green\]; \[result setBlue:blue\]; if (alpha \<= 0.9999) { \[result
 /// setAlpha:floatWrapperWithValue(alpha)\]; } \[result autorelease\]; return
 /// result; } // ... Example (JavaScript): // ... var protoToCssColor =
 /// function(rgb_color) { var redFrac = rgb_color.red || 0.0; var greenFrac =
@@ -729,10 +729,10 @@ class ApnsFcmOptions {
 /// rgbToCssColor(red, green, blue); } var alphaFrac = rgb_color.alpha.value ||
 /// 0.0; var rgbParams = \[red, green, blue\].join(','); return \['rgba(',
 /// rgbParams, ',', alphaFrac, ')'\].join(''); }; var rgbToCssColor =
-/// function(red, green, blue) { var rgbNumber = new Number((red << 16) | (green
-/// << 8) | blue); var hexString = rgbNumber.toString(16); var missingZeros = 6
-/// - hexString.length; var resultBuilder = \['#'\]; for (var i = 0; i <
-/// missingZeros; i++) { resultBuilder.push('0'); }
+/// function(red, green, blue) { var rgbNumber = new Number((red \<\< 16) |
+/// (green \<\< 8) | blue); var hexString = rgbNumber.toString(16); var
+/// missingZeros = 6 - hexString.length; var resultBuilder = \['#'\]; for (var i
+/// = 0; i \< missingZeros; i++) { resultBuilder.push('0'); }
 /// resultBuilder.push(hexString); return resultBuilder.join(''); }; // ...
 typedef Color = $Color;
 

--- a/generated/googleapis/lib/firebasedynamiclinks/v1.dart
+++ b/generated/googleapis/lib/firebasedynamiclinks/v1.dart
@@ -1138,7 +1138,7 @@ class GetIosPostInstallAttributionResponse {
   /// It is the same as the requested_link, if it is long. Parameters from this
   /// should not be used directly (ie: server can default
   /// utm_\[campaign|medium|source\] to a value when requested_link lack them,
-  /// server determine the best fallback_link when requested_link specifies >1
+  /// server determine the best fallback_link when requested_link specifies \>1
   /// fallback links).
   core.String? resolvedLink;
 

--- a/generated/googleapis/lib/firebaserules/v1.dart
+++ b/generated/googleapis/lib/firebaserules/v1.dart
@@ -146,14 +146,14 @@ class ProjectsReleasesResource {
   /// Once a `Release` refers to a `Ruleset`, the rules can be enforced by
   /// Firebase Rules-enabled services. More than one `Release` may be 'live'
   /// concurrently. Consider the following three `Release` names for
-  /// `projects/foo` and the `Ruleset` to which they refer. Release Name ->
-  /// Ruleset Name * projects/foo/releases/prod -> projects/foo/rulesets/uuid123
-  /// * projects/foo/releases/prod/beta -> projects/foo/rulesets/uuid123 *
-  /// projects/foo/releases/prod/v23 -> projects/foo/rulesets/uuid456 The
-  /// relationships reflect a `Ruleset` rollout in progress. The `prod` and
-  /// `prod/beta` releases refer to the same `Ruleset`. However, `prod/v23`
-  /// refers to a new `Ruleset`. The `Ruleset` reference for a `Release` may be
-  /// updated using the UpdateRelease method.
+  /// `projects/foo` and the `Ruleset` to which they refer. Release Name -\>
+  /// Ruleset Name * projects/foo/releases/prod -\>
+  /// projects/foo/rulesets/uuid123 * projects/foo/releases/prod/beta -\>
+  /// projects/foo/rulesets/uuid123 * projects/foo/releases/prod/v23 -\>
+  /// projects/foo/rulesets/uuid456 The relationships reflect a `Ruleset`
+  /// rollout in progress. The `prod` and `prod/beta` releases refer to the same
+  /// `Ruleset`. However, `prod/v23` refers to a new `Ruleset`. The `Ruleset`
+  /// reference for a `Release` may be updated using the UpdateRelease method.
   ///
   /// [request] - The metadata request object.
   ///
@@ -329,15 +329,15 @@ class ProjectsReleasesResource {
   /// [filter] - `Release` filter. The list method supports filters with
   /// restrictions on the `Release.name`, and `Release.ruleset_name`. Example 1:
   /// A filter of 'name=prod*' might return `Release`s with names within
-  /// 'projects/foo' prefixed with 'prod': Name -> Ruleset Name: *
-  /// projects/foo/releases/prod -> projects/foo/rulesets/uuid1234 *
-  /// projects/foo/releases/prod/v1 -> projects/foo/rulesets/uuid1234 *
-  /// projects/foo/releases/prod/v2 -> projects/foo/rulesets/uuid8888 Example 2:
-  /// A filter of `name=prod* ruleset_name=uuid1234` would return only `Release`
-  /// instances for 'projects/foo' with names prefixed with 'prod' referring to
-  /// the same `Ruleset` name of 'uuid1234': Name -> Ruleset Name: *
-  /// projects/foo/releases/prod -> projects/foo/rulesets/1234 *
-  /// projects/foo/releases/prod/v1 -> projects/foo/rulesets/1234 In the
+  /// 'projects/foo' prefixed with 'prod': Name -\> Ruleset Name: *
+  /// projects/foo/releases/prod -\> projects/foo/rulesets/uuid1234 *
+  /// projects/foo/releases/prod/v1 -\> projects/foo/rulesets/uuid1234 *
+  /// projects/foo/releases/prod/v2 -\> projects/foo/rulesets/uuid8888 Example
+  /// 2: A filter of `name=prod* ruleset_name=uuid1234` would return only
+  /// `Release` instances for 'projects/foo' with names prefixed with 'prod'
+  /// referring to the same `Ruleset` name of 'uuid1234': Name -\> Ruleset Name:
+  /// * projects/foo/releases/prod -\> projects/foo/rulesets/1234 *
+  /// projects/foo/releases/prod/v1 -\> projects/foo/rulesets/1234 In the
   /// examples, the filter parameters refer to the search filters are relative
   /// to the project. Fully qualified prefixed may also be used.
   ///

--- a/generated/googleapis/lib/firestore/v1.dart
+++ b/generated/googleapis/lib/firestore/v1.dart
@@ -3535,7 +3535,7 @@ class GoogleFirestoreAdminV1IndexField {
   core.String? fieldPath;
 
   /// Indicates that this field supports ordering by the specified order or
-  /// comparing using =, !=, <, <=, >, >=.
+  /// comparing using =, !=, \<, \<=, \>, \>=.
   /// Possible string values are:
   /// - "ORDER_UNSPECIFIED" : The ordering is unspecified. Not a valid option.
   /// - "ASCENDING" : The field is ordered by ascending field value.
@@ -4664,12 +4664,12 @@ class StructuredQuery {
 
   /// The maximum number of results to return.
   ///
-  /// Applies after all other constraints. Must be >= 0 if specified.
+  /// Applies after all other constraints. Must be \>= 0 if specified.
   core.int? limit;
 
   /// The number of results to skip.
   ///
-  /// Applies before limit, but after all other constraints. Must be >= 0 if
+  /// Applies before limit, but after all other constraints. Must be \>= 0 if
   /// specified.
   core.int? offset;
 

--- a/generated/googleapis/lib/gameservices/v1.dart
+++ b/generated/googleapis/lib/gameservices/v1.dart
@@ -2278,7 +2278,7 @@ class Condition {
 /// IAMContext.principal; or - "iam_principal", a representation of
 /// IAMContext.principal even if a token or authority selector is present; or -
 /// "" (empty string), resulting in a counter with no fields. Examples: counter
-/// { metric: "/debug_access_count" field: "iam_principal" } ==> increment
+/// { metric: "/debug_access_count" field: "iam_principal" } ==\> increment
 /// counter /iam/policy/debug_access_count {iam_principal=\[value of
 /// IAMContext.principal\]}
 class CounterOptions {
@@ -2605,7 +2605,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -3785,14 +3785,14 @@ class OperationStatus {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/gkehub/v1.dart
+++ b/generated/googleapis/lib/gkehub/v1.dart
@@ -1383,7 +1383,7 @@ class Authority {
 
   /// A JSON Web Token (JWT) issuer URI.
   ///
-  /// `issuer` must start with `https://` and be a valid URL with length <2000
+  /// `issuer` must start with `https://` and be a valid URL with length \<2000
   /// characters. If set, then Google will allow valid OIDC tokens from this
   /// issuer to authenticate within the workload_identity_pool. OIDC discovery
   /// will be performed on this URI to validate tokens from the issuer. Clearing
@@ -2667,7 +2667,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -3833,14 +3833,14 @@ class OperationMetadata {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/healthcare/v1.dart
+++ b/generated/googleapis/lib/healthcare/v1.dart
@@ -8697,7 +8697,7 @@ typedef ExportResourcesResponse = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -9271,10 +9271,10 @@ class GoogleCloudHealthcareV1DicomGcsDestination {
   /// application/octet-stream; transfer-syntax=* (raw PixelData in whatever
   /// format it was uploaded in) - image/jpeg;
   /// transfer-syntax=1.2.840.10008.1.2.4.50 (Consumer JPEG) - image/png The
-  /// following extensions are used for output files: - application/dicom ->
-  /// .dcm - image/jpeg -> .jpg - image/png -> .png - application/octet-stream
-  /// -> no extension If unspecified, the instances are exported in the original
-  /// DICOM format they were uploaded in.
+  /// following extensions are used for output files: - application/dicom -\>
+  /// .dcm - image/jpeg -\> .jpg - image/png -\> .png - application/octet-stream
+  /// -\> no extension If unspecified, the instances are exported in the
+  /// original DICOM format they were uploaded in.
   core.String? mimeType;
 
   /// The Cloud Storage destination to export to.
@@ -10999,14 +10999,14 @@ class PatientId {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/iam/v1.dart
+++ b/generated/googleapis/lib/iam/v1.dart
@@ -3327,7 +3327,7 @@ typedef EnableServiceAccountRequest = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -3960,14 +3960,14 @@ class PermissionDelta {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/iap/v1.dart
+++ b/generated/googleapis/lib/iap/v1.dart
@@ -1011,7 +1011,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -1278,14 +1278,14 @@ class OAuthSettings {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/jobs/v3.dart
+++ b/generated/googleapis/lib/jobs/v3.dart
@@ -668,7 +668,7 @@ class ProjectsJobsResource {
   /// [pageSize] - Optional. The maximum number of jobs to be returned per page
   /// of results. If job_view is set to JobView.JOB_VIEW_ID_ONLY, the maximum
   /// allowed page size is 1000. Otherwise, the maximum allowed page size is
-  /// 100. Default is 100 if empty or a number < 1 is specified.
+  /// 100. Default is 100 if empty or a number \< 1 is specified.
   ///
   /// [pageToken] - Optional. The starting point of a query result.
   ///
@@ -2665,7 +2665,7 @@ class Job {
   /// The value determines the sort order of the jobs returned when searching
   /// for jobs using the featured jobs search call, with higher promotional
   /// values being returned first and ties being resolved by relevance sort.
-  /// Only the jobs with a promotionValue >0 are returned in a
+  /// Only the jobs with a promotionValue \>0 are returned in a
   /// FEATURED_JOB_SEARCH. Default value is 0, and negative values are treated
   /// as 0.
   ///
@@ -3085,7 +3085,7 @@ class JobQuery {
   /// This search filter is applied only to Job.compensation_info.
   ///
   /// For example, if the filter is specified as "Hourly job with per-hour
-  /// compensation > $15", only jobs meeting these criteria are searched. If a
+  /// compensation \> $15", only jobs meeting these criteria are searched. If a
   /// filter isn't defined, all open jobs are searched.
   ///
   /// Optional.
@@ -3103,7 +3103,7 @@ class JobQuery {
   /// existence of a key. Boolean expressions (AND/OR/NOT) are supported up to 3
   /// levels of nesting (for example, "((A AND B AND C) OR NOT D) AND E"), a
   /// maximum of 100 comparisons or functions are allowed in the expression. The
-  /// expression must be < 10000 bytes in length. Sample Query:
+  /// expression must be \< 10000 bytes in length. Sample Query:
   /// `(LOWER(driving_license)="class \"a\"" OR EMPTY(driving_license)) AND
   /// driving_years > 10`
   ///
@@ -4075,12 +4075,13 @@ class SearchJobsRequest {
   /// specified. The default search behavior is identical to JOB_SEARCH search
   /// behavior.
   /// - "JOB_SEARCH" : The job search matches against all jobs, and featured
-  /// jobs (jobs with promotionValue > 0) are not specially handled.
+  /// jobs (jobs with promotionValue \> 0) are not specially handled.
   /// - "FEATURED_JOB_SEARCH" : The job search matches only against featured
-  /// jobs (jobs with a promotionValue > 0). This method doesn't return any jobs
-  /// having a promotionValue <= 0. The search results order is determined by
-  /// the promotionValue (jobs with a higher promotionValue are returned higher
-  /// up in the search results), with relevance being used as a tiebreaker.
+  /// jobs (jobs with a promotionValue \> 0). This method doesn't return any
+  /// jobs having a promotionValue \<= 0. The search results order is determined
+  /// by the promotionValue (jobs with a higher promotionValue are returned
+  /// higher up in the search results), with relevance being used as a
+  /// tiebreaker.
   core.String? searchMode;
 
   SearchJobsRequest({

--- a/generated/googleapis/lib/jobs/v4.dart
+++ b/generated/googleapis/lib/jobs/v4.dart
@@ -1022,7 +1022,7 @@ class ProjectsTenantsJobsResource {
   /// [pageSize] - The maximum number of jobs to be returned per page of
   /// results. If job_view is set to JobView.JOB_VIEW_ID_ONLY, the maximum
   /// allowed page size is 1000. Otherwise, the maximum allowed page size is
-  /// 100. Default is 100 if empty or a number < 1 is specified.
+  /// 100. Default is 100 if empty or a number \< 1 is specified.
   ///
   /// [pageToken] - The starting point of a query result.
   ///
@@ -2406,7 +2406,7 @@ class CustomRankingInfo {
   /// the left and right side of the operator is either a numeric
   /// Job.custom_attributes key, integer/double value or an expression that can
   /// be evaluated to a number. Parenthesis are supported to adjust calculation
-  /// precedence. The expression must be < 200 characters in length. The
+  /// precedence. The expression must be \< 200 characters in length. The
   /// expression is considered invalid for a job if the expression references
   /// custom attributes that are not populated on the job or if the expression
   /// results in a divide by zero. If an expression is invalid for a job, that
@@ -2787,7 +2787,7 @@ class Job {
   /// The value determines the sort order of the jobs returned when searching
   /// for jobs using the featured jobs search call, with higher promotional
   /// values being returned first and ties being resolved by relevance sort.
-  /// Only the jobs with a promotionValue >0 are returned in a
+  /// Only the jobs with a promotionValue \>0 are returned in a
   /// FEATURED_JOB_SEARCH. Default value is 0, and negative values are treated
   /// as 0.
   core.int? promotionValue;
@@ -3192,7 +3192,7 @@ class JobQuery {
   /// This search filter is applied only to Job.compensation_info.
   ///
   /// For example, if the filter is specified as "Hourly job with per-hour
-  /// compensation > $15", only jobs meeting these criteria are searched. If a
+  /// compensation \> $15", only jobs meeting these criteria are searched. If a
   /// filter isn't defined, all open jobs are searched.
   CompensationFilter? compensationFilter;
 
@@ -3208,7 +3208,7 @@ class JobQuery {
   /// existence of a key. Boolean expressions (AND/OR/NOT) are supported up to 3
   /// levels of nesting (for example, "((A AND B AND C) OR NOT D) AND E"), a
   /// maximum of 100 comparisons or functions are allowed in the expression. The
-  /// expression must be < 10000 bytes in length. Sample Query:
+  /// expression must be \< 10000 bytes in length. Sample Query:
   /// `(LOWER(driving_license)="class \"a\"" OR EMPTY(driving_license)) AND
   /// driving_years > 10`
   core.String? customAttributeFilter;
@@ -4293,12 +4293,13 @@ class SearchJobsRequest {
   /// specified. The default search behavior is identical to JOB_SEARCH search
   /// behavior.
   /// - "JOB_SEARCH" : The job search matches against all jobs, and featured
-  /// jobs (jobs with promotionValue > 0) are not specially handled.
+  /// jobs (jobs with promotionValue \> 0) are not specially handled.
   /// - "FEATURED_JOB_SEARCH" : The job search matches only against featured
-  /// jobs (jobs with a promotionValue > 0). This method doesn't return any jobs
-  /// having a promotionValue <= 0. The search results order is determined by
-  /// the promotionValue (jobs with a higher promotionValue are returned higher
-  /// up in the search results), with relevance being used as a tiebreaker.
+  /// jobs (jobs with a promotionValue \> 0). This method doesn't return any
+  /// jobs having a promotionValue \<= 0. The search results order is determined
+  /// by the promotionValue (jobs with a higher promotionValue are returned
+  /// higher up in the search results), with relevance being used as a
+  /// tiebreaker.
   core.String? searchMode;
 
   SearchJobsRequest({

--- a/generated/googleapis/lib/language/v1.dart
+++ b/generated/googleapis/lib/language/v1.dart
@@ -1095,7 +1095,7 @@ class Entity {
   /// locality plus whichever additional elements appear in the text: *
   /// `street_number` - street number * `locality` - city or town *
   /// `street_name` - street/route name, if detected * `postal_code` - postal
-  /// code, if detected * `country` - country, if detected< * `broad_region` -
+  /// code, if detected * `country` - country, if detected\< * `broad_region` -
   /// administrative area, such as the state, if detected * `narrow_region` -
   /// smaller administrative area, such as county, if detected * `sublocality` -
   /// used in Asian addresses to demark a district within a city, if detected

--- a/generated/googleapis/lib/logging/v2.dart
+++ b/generated/googleapis/lib/logging/v2.dart
@@ -8460,7 +8460,7 @@ class BigQueryOptions {
 /// sequence of N buckets for a distribution consists of an underflow bucket
 /// (number 0), zero or more finite buckets (number 1 through N - 2) and an
 /// overflow bucket (number N - 1). The buckets are contiguous: the lower bound
-/// of bucket i (i > 0) is the same as the upper bound of bucket i - 1. The
+/// of bucket i (i \> 0) is the same as the upper bound of bucket i - 1. The
 /// buckets span the whole range of finite values: lower bound of the underflow
 /// bucket is -infinity and the upper bound of the overflow bucket is +infinity.
 /// The finite buckets are so-called because both bounds are finite.
@@ -8739,9 +8739,9 @@ typedef Empty = $Empty;
 /// Specifies a set of buckets with arbitrary widths.There are size(bounds) + 1
 /// (= N) buckets.
 ///
-/// Bucket i has the following boundaries:Upper bound (0 <= i < N-1): boundsi
-/// Lower bound (1 <= i < N); boundsi - 1The bounds field must contain at least
-/// one element. If bounds has only one element, then there are no finite
+/// Bucket i has the following boundaries:Upper bound (0 \<= i \< N-1): boundsi
+/// Lower bound (1 \<= i \< N); boundsi - 1The bounds field must contain at
+/// least one element. If bounds has only one element, then there are no finite
 /// buckets, and that single element is the common boundary of the overflow and
 /// underflow buckets.
 typedef Explicit = $Explicit;
@@ -8751,8 +8751,9 @@ typedef Explicit = $Explicit;
 ///
 /// Each bucket represents a constant relative uncertainty on a specific value
 /// in the bucket.There are num_finite_buckets + 2 (= N) buckets. Bucket i has
-/// the following boundaries:Upper bound (0 <= i < N-1): scale * (growth_factor
-/// ^ i). Lower bound (1 <= i < N): scale * (growth_factor ^ (i - 1)).
+/// the following boundaries:Upper bound (0 \<= i \< N-1): scale *
+/// (growth_factor ^ i). Lower bound (1 \<= i \< N): scale * (growth_factor ^ (i
+/// - 1)).
 typedef Exponential = $Exponential;
 
 /// A common proto for logging HTTP requests.
@@ -8929,8 +8930,8 @@ typedef LabelDescriptor = $LabelDescriptor;
 ///
 /// Each bucket represents a constant absolute uncertainty on the specific value
 /// in the bucket.There are num_finite_buckets + 2 (= N) buckets. Bucket i has
-/// the following boundaries:Upper bound (0 <= i < N-1): offset + (width * i).
-/// Lower bound (1 <= i < N): offset + (width * (i - 1)).
+/// the following boundaries:Upper bound (0 \<= i \< N-1): offset + (width * i).
+/// Lower bound (1 \<= i \< N): offset + (width * (i - 1)).
 typedef Linear = $Linear;
 
 /// The response from ListBuckets.
@@ -9940,7 +9941,7 @@ class LogExclusion {
   /// (https://cloud.google.com/logging/docs/view/advanced-queries#sample), you
   /// can exclude less than 100% of the matching log entries.For example, the
   /// following query matches 99% of low-severity log entries from Google Cloud
-  /// Storage buckets:resource.type=gcs_bucket severity<ERROR sample(insertId,
+  /// Storage buckets:resource.type=gcs_bucket severity\<ERROR sample(insertId,
   /// 0.99)
   ///
   /// Required.
@@ -10095,8 +10096,8 @@ class LogMetric {
   /// (https://cloud.google.com/logging/docs/view/advanced_filters) which is
   /// used to match log entries.
   ///
-  /// Example: "resource.type=gae_app AND severity>=ERROR" The maximum length of
-  /// the filter is 20000 characters.
+  /// Example: "resource.type=gae_app AND severity\>=ERROR" The maximum length
+  /// of the filter is 20000 characters.
   ///
   /// Required.
   core.String? filter;
@@ -10315,7 +10316,7 @@ class LogSink {
   /// The only exported log entries are those that are in the resource owning
   /// the sink and that match the filter.For
   /// example:logName="projects/\[PROJECT_ID\]/logs/\[LOG_ID\]" AND
-  /// severity>=ERROR
+  /// severity\>=ERROR
   ///
   /// Optional.
   core.String? filter;

--- a/generated/googleapis/lib/managedidentities/v1.dart
+++ b/generated/googleapis/lib/managedidentities/v1.dart
@@ -2053,7 +2053,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -3205,14 +3205,14 @@ class Peering {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/ml/v1.dart
+++ b/generated/googleapis/lib/ml/v1.dart
@@ -3211,7 +3211,7 @@ class GoogleCloudMlV1Config {
 class GoogleCloudMlV1ContainerPort {
   /// Number of the port to expose on the container.
   ///
-  /// This must be a valid port number: 0 < PORT_NUMBER < 65536.
+  /// This must be a valid port number: 0 \< PORT_NUMBER \< 65536.
   core.int? containerPort;
 
   GoogleCloudMlV1ContainerPort({
@@ -6997,14 +6997,14 @@ class GoogleIamV1Binding {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class GoogleIamV1Policy {
@@ -7267,7 +7267,7 @@ typedef GoogleRpcStatus = $Status;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"

--- a/generated/googleapis/lib/monitoring/v3.dart
+++ b/generated/googleapis/lib/monitoring/v3.dart
@@ -324,7 +324,7 @@ class FoldersTimeSeriesResource {
   /// computed at each point of the alignment period prior to the above
   /// calculation to smooth the metric and prevent false positives from very
   /// short-lived spikes. The moving mean is only applicable for data whose
-  /// values are >= 0. Any values < 0 are treated as a missing datapoint, and
+  /// values are \>= 0. Any values \< 0 are treated as a missing datapoint, and
   /// are ignored. While DELTA metrics are accepted by this alignment, special
   /// care should be taken that the values for the metric will always be
   /// positive. The output is a GAUGE metric with value_type DOUBLE.
@@ -555,7 +555,7 @@ class FoldersTimeSeriesResource {
   /// computed at each point of the alignment period prior to the above
   /// calculation to smooth the metric and prevent false positives from very
   /// short-lived spikes. The moving mean is only applicable for data whose
-  /// values are >= 0. Any values < 0 are treated as a missing datapoint, and
+  /// values are \>= 0. Any values \< 0 are treated as a missing datapoint, and
   /// are ignored. While DELTA metrics are accepted by this alignment, special
   /// care should be taken that the values for the metric will always be
   /// positive. The output is a GAUGE metric with value_type DOUBLE.
@@ -869,7 +869,7 @@ class OrganizationsTimeSeriesResource {
   /// computed at each point of the alignment period prior to the above
   /// calculation to smooth the metric and prevent false positives from very
   /// short-lived spikes. The moving mean is only applicable for data whose
-  /// values are >= 0. Any values < 0 are treated as a missing datapoint, and
+  /// values are \>= 0. Any values \< 0 are treated as a missing datapoint, and
   /// are ignored. While DELTA metrics are accepted by this alignment, special
   /// care should be taken that the values for the metric will always be
   /// positive. The output is a GAUGE metric with value_type DOUBLE.
@@ -1100,7 +1100,7 @@ class OrganizationsTimeSeriesResource {
   /// computed at each point of the alignment period prior to the above
   /// calculation to smooth the metric and prevent false positives from very
   /// short-lived spikes. The moving mean is only applicable for data whose
-  /// values are >= 0. Any values < 0 are treated as a missing datapoint, and
+  /// values are \>= 0. Any values \< 0 are treated as a missing datapoint, and
   /// are ignored. While DELTA metrics are accepted by this alignment, special
   /// care should be taken that the values for the metric will always be
   /// positive. The output is a GAUGE metric with value_type DOUBLE.
@@ -3014,7 +3014,7 @@ class ProjectsTimeSeriesResource {
   /// computed at each point of the alignment period prior to the above
   /// calculation to smooth the metric and prevent false positives from very
   /// short-lived spikes. The moving mean is only applicable for data whose
-  /// values are >= 0. Any values < 0 are treated as a missing datapoint, and
+  /// values are \>= 0. Any values \< 0 are treated as a missing datapoint, and
   /// are ignored. While DELTA metrics are accepted by this alignment, special
   /// care should be taken that the values for the metric will always be
   /// positive. The output is a GAUGE metric with value_type DOUBLE.
@@ -3245,7 +3245,7 @@ class ProjectsTimeSeriesResource {
   /// computed at each point of the alignment period prior to the above
   /// calculation to smooth the metric and prevent false positives from very
   /// short-lived spikes. The moving mean is only applicable for data whose
-  /// values are >= 0. Any values < 0 are treated as a missing datapoint, and
+  /// values are \>= 0. Any values \< 0 are treated as a missing datapoint, and
   /// are ignored. While DELTA metrics are accepted by this alignment, special
   /// care should be taken that the values for the metric will always be
   /// positive. The output is a GAUGE metric with value_type DOUBLE.
@@ -3520,7 +3520,7 @@ class ProjectsUptimeCheckConfigsResource {
   ///
   /// [pageSize] - The maximum number of results to return in a single response.
   /// The server may further constrain the maximum number of results returned in
-  /// a single page. If the page_size is <=0, the server will decide the number
+  /// a single page. If the page_size is \<=0, the server will decide the number
   /// of results to be returned.
   ///
   /// [pageToken] - If this field is not empty then it must contain the
@@ -4144,7 +4144,7 @@ class UptimeCheckIpsResource {
   ///
   /// [pageSize] - The maximum number of results to return in a single response.
   /// The server may further constrain the maximum number of results returned in
-  /// a single page. If the page_size is <=0, the server will decide the number
+  /// a single page. If the page_size is \<=0, the server will decide the number
   /// of results to be returned. NOTE: this field is not yet implemented
   ///
   /// [pageToken] - If this field is not empty then it must contain the
@@ -4412,7 +4412,7 @@ class Aggregation {
   /// computed at each point of the alignment period prior to the above
   /// calculation to smooth the metric and prevent false positives from very
   /// short-lived spikes. The moving mean is only applicable for data whose
-  /// values are >= 0. Any values < 0 are treated as a missing datapoint, and
+  /// values are \>= 0. Any values \< 0 are treated as a missing datapoint, and
   /// are ignored. While DELTA metrics are accepted by this alignment, special
   /// care should be taken that the values for the metric will always be
   /// positive. The output is a GAUGE metric with value_type DOUBLE.
@@ -4833,7 +4833,7 @@ class BasicSli {
 /// sequence of N buckets for a distribution consists of an underflow bucket
 /// (number 0), zero or more finite buckets (number 1 through N - 2) and an
 /// overflow bucket (number N - 1). The buckets are contiguous: the lower bound
-/// of bucket i (i > 0) is the same as the upper bound of bucket i - 1. The
+/// of bucket i (i \> 0) is the same as the upper bound of bucket i - 1. The
 /// buckets span the whole range of finite values: lower bound of the underflow
 /// bucket is -infinity and the upper bound of the overflow bucket is +infinity.
 /// The finite buckets are so-called because both bounds are finite.
@@ -4970,7 +4970,7 @@ class CollectdPayload {
 
   /// The measurement metadata.
   ///
-  /// Example: "process_id" -> 12345
+  /// Example: "process_id" -\> 12345
   core.Map<core.String, TypedValue>? metadata;
 
   /// The name of the plugin.
@@ -5827,9 +5827,9 @@ class Exemplar {
 /// Specifies a set of buckets with arbitrary widths.There are size(bounds) + 1
 /// (= N) buckets.
 ///
-/// Bucket i has the following boundaries:Upper bound (0 <= i < N-1): boundsi
-/// Lower bound (1 <= i < N); boundsi - 1The bounds field must contain at least
-/// one element. If bounds has only one element, then there are no finite
+/// Bucket i has the following boundaries:Upper bound (0 \<= i \< N-1): boundsi
+/// Lower bound (1 \<= i \< N); boundsi - 1The bounds field must contain at
+/// least one element. If bounds has only one element, then there are no finite
 /// buckets, and that single element is the common boundary of the overflow and
 /// underflow buckets.
 typedef Explicit = $Explicit;
@@ -5839,8 +5839,9 @@ typedef Explicit = $Explicit;
 ///
 /// Each bucket represents a constant relative uncertainty on a specific value
 /// in the bucket.There are num_finite_buckets + 2 (= N) buckets. Bucket i has
-/// the following boundaries:Upper bound (0 <= i < N-1): scale * (growth_factor
-/// ^ i). Lower bound (1 <= i < N): scale * (growth_factor ^ (i - 1)).
+/// the following boundaries:Upper bound (0 \<= i \< N-1): scale *
+/// (growth_factor ^ i). Lower bound (1 \<= i \< N): scale * (growth_factor ^ (i
+/// - 1)).
 typedef Exponential = $Exponential;
 
 /// A single field of a message type.
@@ -6385,7 +6386,7 @@ class InternalChecker {
 
 /// Canonical service scoped to an Istio mesh.
 ///
-/// Anthos clusters running ASM >= 1.6.8 will have their services ingested as
+/// Anthos clusters running ASM \>= 1.6.8 will have their services ingested as
 /// this type.
 class IstioCanonicalService {
   /// The name of the canonical service underlying this service.
@@ -6544,8 +6545,8 @@ class LatencyCriteria {
 ///
 /// Each bucket represents a constant absolute uncertainty on the specific value
 /// in the bucket.There are num_finite_buckets + 2 (= N) buckets. Bucket i has
-/// the following boundaries:Upper bound (0 <= i < N-1): offset + (width * i).
-/// Lower bound (1 <= i < N): offset + (width * (i - 1)).
+/// the following boundaries:Upper bound (0 \<= i \< N-1): offset + (width * i).
+/// Lower bound (1 \<= i \< N): offset + (width * (i - 1)).
 typedef Linear = $Linear;
 
 /// The protocol for the ListAlertPolicies response.
@@ -7115,7 +7116,7 @@ class LogMatch {
 
 /// Istio service scoped to an Istio mesh.
 ///
-/// Anthos clusters running ASM < 1.6.8 will have their services ingested as
+/// Anthos clusters running ASM \< 1.6.8 will have their services ingested as
 /// this type.
 class MeshIstio {
   /// Identifier for the mesh in which this Istio service is defined.
@@ -7520,7 +7521,7 @@ class MetricDescriptor {
 typedef MetricDescriptorMetadata = $MetricDescriptorMetadata01;
 
 /// A MetricRange is used when each window is good when the value x of a single
-/// TimeSeries satisfies range.min <= x <= range.max.
+/// TimeSeries satisfies range.min \<= x \<= range.max.
 ///
 /// The provided TimeSeries must have ValueType = INT64 or ValueType = DOUBLE
 /// and MetricKind = GAUGE.
@@ -8385,7 +8386,7 @@ class PerformanceThreshold {
   /// RequestBasedSli to evaluate to judge window quality.
   RequestBasedSli? performance;
 
-  /// If window performance >= threshold, the window is counted as good.
+  /// If window performance \>= threshold, the window is counted as good.
   core.double? threshold;
 
   PerformanceThreshold({
@@ -8837,7 +8838,7 @@ class Service {
 /// parameters. Alternatively, a "custom" SLI can be defined with a query to the
 /// underlying metric store. An SLI is defined to be good_service /
 /// total_service over any queried time interval. The value of performance
-/// always falls into the range 0 <= performance <= 1. A custom SLI describes
+/// always falls into the range 0 \<= performance \<= 1. A custom SLI describes
 /// how to compute this ratio, whether this is by dividing values from a pair of
 /// time series, cutting a Distribution into good and bad counts, or counting
 /// time windows in which the service complies with a criterion. For separation
@@ -8916,7 +8917,7 @@ class ServiceLevelObjective {
   /// The fraction of service that must be good in order for this objective to
   /// be met.
   ///
-  /// 0 < goal <= 0.999.
+  /// 0 \< goal \<= 0.999.
   core.double? goal;
 
   /// Resource name for this ServiceLevelObjective.

--- a/generated/googleapis/lib/mybusinesslodging/v1.dart
+++ b/generated/googleapis/lib/mybusinesslodging/v1.dart
@@ -2441,7 +2441,7 @@ class GuestUnitType {
 
   /// Short, English label or name of the GuestUnitType.
   ///
-  /// Target <50 chars.
+  /// Target \<50 chars.
   ///
   /// Required.
   core.String? label;

--- a/generated/googleapis/lib/networkconnectivity/v1.dart
+++ b/generated/googleapis/lib/networkconnectivity/v1.dart
@@ -1528,7 +1528,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -2131,14 +2131,14 @@ class OperationMetadata {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/networkmanagement/v1.dart
+++ b/generated/googleapis/lib/networkmanagement/v1.dart
@@ -1571,7 +1571,7 @@ class EndpointInfo {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -2393,14 +2393,14 @@ class OperationMetadata {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/networksecurity/v1.dart
+++ b/generated/googleapis/lib/networksecurity/v1.dart
@@ -1850,7 +1850,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -2084,14 +2084,14 @@ class GoogleIamV1Binding {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class GoogleIamV1Policy {

--- a/generated/googleapis/lib/networkservices/v1.dart
+++ b/generated/googleapis/lib/networkservices/v1.dart
@@ -1640,7 +1640,7 @@ class EndpointPolicy {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -1857,14 +1857,14 @@ typedef OperationMetadata = $OperationMetadata00;
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/notebooks/v1.dart
+++ b/generated/googleapis/lib/notebooks/v1.dart
@@ -3081,7 +3081,7 @@ class ExecutionTemplate {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -4420,14 +4420,14 @@ class OperationMetadata {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/orgpolicy/v2.dart
+++ b/generated/googleapis/lib/orgpolicy/v2.dart
@@ -1610,7 +1610,7 @@ typedef GoogleProtobufEmpty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"

--- a/generated/googleapis/lib/pagespeedonline/v5.dart
+++ b/generated/googleapis/lib/pagespeedonline/v5.dart
@@ -191,7 +191,7 @@ class AuditRefs {
 /// A proportion of data in the total distribution, bucketed by a min/max
 /// percentage.
 ///
-/// Each bucket's range is bounded by min <= x < max, In millisecond.
+/// Each bucket's range is bounded by min \<= x \< max, In millisecond.
 class Bucket {
   /// Upper bound for a bucket's range.
   core.int? max;

--- a/generated/googleapis/lib/people/v1.dart
+++ b/generated/googleapis/lib/people/v1.dart
@@ -1026,12 +1026,12 @@ class PeopleResource {
   ///
   /// [resourceNames] - Required. The resource names of the people to provide
   /// information about. It's repeatable. The URL query parameter should be
-  /// resourceNames=<name1>&resourceNames=<name2>&... - To get information about
-  /// the authenticated user, specify `people/me`. - To get information about a
-  /// google account, specify `people/{account_id}`. - To get information about
-  /// a contact, specify the resource name that identifies the contact as
-  /// returned by `people.connections.list`. There is a maximum of 200 resource
-  /// names.
+  /// resourceNames=\<name1\>&resourceNames=\<name2\>&... - To get information
+  /// about the authenticated user, specify `people/me`. - To get information
+  /// about a google account, specify `people/{account_id}`. - To get
+  /// information about a contact, specify the resource name that identifies the
+  /// contact as returned by `people.connections.list`. There is a maximum of
+  /// 200 resource names.
   ///
   /// [sources] - Optional. A mask of what source types to return. Defaults to
   /// READ_SOURCE_TYPE_CONTACT and READ_SOURCE_TYPE_PROFILE if not set.

--- a/generated/googleapis/lib/playablelocations/v3.dart
+++ b/generated/googleapis/lib/playablelocations/v3.dart
@@ -774,8 +774,8 @@ class GoogleMapsPlayablelocationsV3SampleSpacingOptions {
   /// 1. Add locations for X, within 400m of each other. 2. Add locations for Y,
   /// without any spacing. 3. Finally, add locations for Z within 200m of each
   /// other as well X and Y. The distance diagram between those locations end up
-  /// as: * From->To. * X->X: 400m * Y->X, Y->Y: unspecified. * Z->X, Z->Y,
-  /// Z->Z: 200m.
+  /// as: * From-\>To. * X-\>X: 400m * Y-\>X, Y-\>Y: unspecified. * Z-\>X,
+  /// Z-\>Y, Z-\>Z: 200m.
   ///
   /// Required.
   core.double? minSpacingMeters;

--- a/generated/googleapis/lib/policysimulator/v1.dart
+++ b/generated/googleapis/lib/policysimulator/v1.dart
@@ -1815,14 +1815,14 @@ class GoogleIamV1Binding {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class GoogleIamV1Policy {
@@ -2048,7 +2048,7 @@ typedef GoogleTypeDate = $Date;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"

--- a/generated/googleapis/lib/policytroubleshooter/v1.dart
+++ b/generated/googleapis/lib/policytroubleshooter/v1.dart
@@ -622,14 +622,14 @@ class GoogleIamV1Binding {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class GoogleIamV1Policy {
@@ -728,7 +728,7 @@ class GoogleIamV1Policy {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"

--- a/generated/googleapis/lib/privateca/v1.dart
+++ b/generated/googleapis/lib/privateca/v1.dart
@@ -3845,7 +3845,7 @@ typedef EnableCertificateAuthorityRequest = $Request02;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -4777,14 +4777,14 @@ typedef OperationMetadata = $OperationMetadata00;
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/pubsub/v1.dart
+++ b/generated/googleapis/lib/pubsub/v1.dart
@@ -2337,7 +2337,7 @@ class ExpirationPolicy {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -2719,14 +2719,14 @@ class OidcToken {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/pubsublite/v1.dart
+++ b/generated/googleapis/lib/pubsublite/v1.dart
@@ -1522,12 +1522,12 @@ typedef CancelOperationRequest = $Empty;
 class Capacity {
   /// Publish throughput capacity per partition in MiB/s.
   ///
-  /// Must be >= 4 and <= 16.
+  /// Must be \>= 4 and \<= 16.
   core.int? publishMibPerSec;
 
   /// Subscribe throughput capacity per partition in MiB/s.
   ///
-  /// Must be >= 4 and <= 32.
+  /// Must be \>= 4 and \<= 32.
   core.int? subscribeMibPerSec;
 
   Capacity({
@@ -1637,7 +1637,7 @@ class ComputeHeadCursorResponse {
 class ComputeMessageStatsRequest {
   /// The exclusive end of the range.
   ///
-  /// The range is empty if end_cursor <= start_cursor. Specifying a
+  /// The range is empty if end_cursor \<= start_cursor. Specifying a
   /// start_cursor before the first message and an end_cursor after the last
   /// message will retrieve all messages.
   Cursor? endCursor;
@@ -2511,7 +2511,7 @@ class TimeTarget {
   /// Request the cursor of the first message with publish time greater than or
   /// equal to `publish_time`.
   ///
-  /// All messages thereafter are guaranteed to have publish times >=
+  /// All messages thereafter are guaranteed to have publish times \>=
   /// `publish_time`.
   core.String? publishTime;
 

--- a/generated/googleapis/lib/realtimebidding/v1.dart
+++ b/generated/googleapis/lib/realtimebidding/v1.dart
@@ -3932,7 +3932,7 @@ class PretargetingConfig {
   /// The targeted minimum viewability decile, ranging in values \[0, 10\].
   ///
   /// A value of 5 means that the configuration will only match adslots for
-  /// which we predict at least 50% viewability. Values > 10 will be rounded
+  /// which we predict at least 50% viewability. Values \> 10 will be rounded
   /// down to 10. An unset value or a value of 0 indicates that bid requests
   /// will be sent regardless of viewability.
   core.int? minimumViewabilityDecile;

--- a/generated/googleapis/lib/resourcesettings/v1.dart
+++ b/generated/googleapis/lib/resourcesettings/v1.dart
@@ -736,7 +736,7 @@ class GoogleCloudResourcesettingsV1SettingMetadata {
   /// - "STRING_SET" : A string set setting.
   /// - "ENUM_VALUE" : A Enum setting
   /// - "DURATION_VALUE" : A Duration setting
-  /// - "STRING_MAP" : A string->string map setting
+  /// - "STRING_MAP" : A string-\>string map setting
   core.String? dataType;
 
   /// The value provided by Setting.effective_value if no setting value is
@@ -882,7 +882,7 @@ class GoogleCloudResourcesettingsV1ValueEnumValue {
       };
 }
 
-/// A string->string map value that can hold a map of string keys to string
+/// A string-\>string map value that can hold a map of string keys to string
 /// values.
 ///
 /// The maximum length of each string is 200 characters and there can be a

--- a/generated/googleapis/lib/retail/v2.dart
+++ b/generated/googleapis/lib/retail/v2.dart
@@ -3490,17 +3490,17 @@ class GoogleCloudRetailV2Product {
   /// This field is repeated for supporting one product belonging to several
   /// parallel categories. Strongly recommended using the full path for better
   /// search / recommendation quality. To represent full path of category, use
-  /// '>' sign to separate different hierarchies. If '>' is part of the category
-  /// name, please replace it with other character(s). For example, if a shoes
-  /// product belongs to both \["Shoes & Accessories" -> "Shoes"\] and \["Sports
-  /// & Fitness" -> "Athletic Clothing" -> "Shoes"\], it could be represented
-  /// as: "categories": \[ "Shoes & Accessories > Shoes", "Sports & Fitness >
-  /// Athletic Clothing > Shoes" \] Must be set for Type.PRIMARY Product
-  /// otherwise an INVALID_ARGUMENT error is returned. At most 250 values are
-  /// allowed per Product. Empty values are not allowed. Each value must be a
-  /// UTF-8 encoded string with a length limit of 5,000 characters. Otherwise,
-  /// an INVALID_ARGUMENT error is returned. Google Merchant Center property
-  /// google_product_category. Schema.org property
+  /// '\>' sign to separate different hierarchies. If '\>' is part of the
+  /// category name, please replace it with other character(s). For example, if
+  /// a shoes product belongs to both \["Shoes & Accessories" -\> "Shoes"\] and
+  /// \["Sports & Fitness" -\> "Athletic Clothing" -\> "Shoes"\], it could be
+  /// represented as: "categories": \[ "Shoes & Accessories \> Shoes", "Sports &
+  /// Fitness \> Athletic Clothing \> Shoes" \] Must be set for Type.PRIMARY
+  /// Product otherwise an INVALID_ARGUMENT error is returned. At most 250
+  /// values are allowed per Product. Empty values are not allowed. Each value
+  /// must be a UTF-8 encoded string with a length limit of 5,000 characters.
+  /// Otherwise, an INVALID_ARGUMENT error is returned. Google Merchant Center
+  /// property google_product_category. Schema.org property
   /// [Product.category](https://schema.org/category).
   /// \[mc_google_product_category\]:
   /// https://support.google.com/merchants/answer/6324436
@@ -4531,11 +4531,11 @@ class GoogleCloudRetailV2SearchRequest {
   ///
   /// Required for category navigation queries to achieve good search quality.
   /// The format should be the same as UserEvent.page_categories; To represent
-  /// full path of category, use '>' sign to separate different hierarchies. If
-  /// '>' is part of the category name, please replace it with other
+  /// full path of category, use '\>' sign to separate different hierarchies. If
+  /// '\>' is part of the category name, please replace it with other
   /// character(s). Category pages include special pages such as sales or
   /// promotions. For instance, a special sale page may have the category
-  /// hierarchy: "pageCategories" : \["Sales > 2017 Black Friday Deals"\].
+  /// hierarchy: "pageCategories" : \["Sales \> 2017 Black Friday Deals"\].
   core.List<core.String>? pageCategories;
 
   /// Maximum number of Products to return.
@@ -4902,9 +4902,9 @@ class GoogleCloudRetailV2SearchRequestFacetSpec {
 class GoogleCloudRetailV2SearchRequestFacetSpecFacetKey {
   /// Only get facet values that contains the given strings.
   ///
-  /// For example, suppose "categories" has three values "Women > Shoe", "Women
-  /// > Dress" and "Men > Shoe". If set "contains" to "Shoe", the "categories"
-  /// facet will give only "Women > Shoe" and "Men > Shoe". Only supported on
+  /// For example, suppose "categories" has three values "Women \> Shoe", "Women
+  /// \> Dress" and "Men \> Shoe". If set "contains" to "Shoe", the "categories"
+  /// facet will give only "Women \> Shoe" and "Men \> Shoe". Only supported on
   /// textual fields. Maximum is 10.
   core.List<core.String>? contains;
 
@@ -4943,10 +4943,10 @@ class GoogleCloudRetailV2SearchRequestFacetSpecFacetKey {
 
   /// Only get facet values that start with the given string prefix.
   ///
-  /// For example, suppose "categories" has three values "Women > Shoe", "Women
-  /// > Dress" and "Men > Shoe". If set "prefixes" to "Women", the "categories"
-  /// facet will give only "Women > Shoe" and "Women > Dress". Only supported on
-  /// textual fields. Maximum is 10.
+  /// For example, suppose "categories" has three values "Women \> Shoe", "Women
+  /// \> Dress" and "Men \> Shoe". If set "prefixes" to "Women", the
+  /// "categories" facet will give only "Women \> Shoe" and "Women \> Dress".
+  /// Only supported on textual fields. Maximum is 10.
   core.List<core.String>? prefixes;
 
   /// The query that is used to compute facet for the given facet key.
@@ -5599,11 +5599,11 @@ class GoogleCloudRetailV2UserEvent {
 
   /// The categories associated with a category page.
   ///
-  /// To represent full path of category, use '>' sign to separate different
-  /// hierarchies. If '>' is part of the category name, please replace it with
+  /// To represent full path of category, use '\>' sign to separate different
+  /// hierarchies. If '\>' is part of the category name, please replace it with
   /// other character(s). Category pages include special pages such as sales or
   /// promotions. For instance, a special sale page may have the category
-  /// hierarchy: "pageCategories" : \["Sales > 2017 Black Friday Deals"\].
+  /// hierarchy: "pageCategories" : \["Sales \> 2017 Black Friday Deals"\].
   /// Required for `category-page-view` events. At least one of search_query or
   /// page_categories is required for `search` events. Other event types should
   /// not set this field. Otherwise, an INVALID_ARGUMENT error is returned.

--- a/generated/googleapis/lib/run/v1.dart
+++ b/generated/googleapis/lib/run/v1.dart
@@ -3036,7 +3036,7 @@ class Container {
 class ContainerPort {
   /// (Optional) Port number the container listens on.
   ///
-  /// This must be a valid port number, 0 < x < 65536.
+  /// This must be a valid port number, 0 \< x \< 65536.
   core.int? containerPort;
 
   /// (Optional) If specified, used to specify which protocol to use.
@@ -3404,7 +3404,7 @@ class ExecAction {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -4393,14 +4393,14 @@ class OwnerReference {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/secretmanager/v1.dart
+++ b/generated/googleapis/lib/secretmanager/v1.dart
@@ -1204,7 +1204,7 @@ typedef EnableSecretVersionRequest = $SecretVersionRequest;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -1361,14 +1361,14 @@ typedef Location = $Location00;
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/securitycenter/v1.dart
+++ b/generated/googleapis/lib/securitycenter/v1.dart
@@ -3445,7 +3445,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -5129,14 +5129,14 @@ class OrganizationSettings {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/serviceconsumermanagement/v1.dart
+++ b/generated/googleapis/lib/serviceconsumermanagement/v1.dart
@@ -1454,14 +1454,14 @@ typedef DeleteTenantProjectRequest = $TenantProjectRequest;
 
 /// `Documentation` provides the information for describing a service.
 ///
-/// Example: documentation: summary: > The Google Calendar API gives access to
+/// Example: documentation: summary: \> The Google Calendar API gives access to
 /// most calendar features. pages: - name: Overview content: (== include
 /// google/foo/overview.md ==) - name: Tutorial content: (== include
 /// google/foo/tutorial.md ==) subpages; - name: Java content: (== include
 /// google/foo/tutorial_java.md ==) rules: - selector:
-/// google.calendar.Calendar.Get description: > ... - selector:
-/// google.calendar.Calendar.Put description: > ... Documentation is provided in
-/// markdown syntax. In addition to standard markdown features, definition
+/// google.calendar.Calendar.Get description: \> ... - selector:
+/// google.calendar.Calendar.Put description: \> ... Documentation is provided
+/// in markdown syntax. In addition to standard markdown features, definition
 /// lists, tables and fenced code blocks are supported. Section headers can be
 /// provided and are interpreted relative to the section nesting of the context
 /// where a documentation fragment is embedded. Documentation from the IDL is

--- a/generated/googleapis/lib/servicecontrol/v1.dart
+++ b/generated/googleapis/lib/servicecontrol/v1.dart
@@ -1147,7 +1147,7 @@ class Distribution {
 
   /// The total number of samples in the distribution.
   ///
-  /// Must be >= 0.
+  /// Must be \>= 0.
   core.String? count;
 
   /// Example points.
@@ -1323,8 +1323,8 @@ class ExplicitBuckets {
   /// bound_size() - 1. Note that there are no finite buckets at all if 'bound'
   /// only contains a single element; in that special case the single bound
   /// defines the boundary between the underflow and overflow buckets. bucket
-  /// number lower bound upper bound i == 0 (underflow) -inf bound\[i\] 0 < i <
-  /// bound_size() bound\[i-1\] bound\[i\] i == bound_size() (overflow)
+  /// number lower bound upper bound i == 0 (underflow) -inf bound\[i\] 0 \< i
+  /// \< bound_size() bound\[i-1\] bound\[i\] i == bound_size() (overflow)
   /// bound\[i-1\] +inf
   core.List<core.double>? bounds;
 
@@ -1365,7 +1365,7 @@ class ExponentialBuckets {
   /// growth_factor^(i-1), scale * growth_factor^i) where i ranges from 1 to
   /// num_finite_buckets inclusive.
   ///
-  /// Must be > 0.
+  /// Must be \> 0.
   core.double? scale;
 
   ExponentialBuckets({

--- a/generated/googleapis/lib/servicedirectory/v1.dart
+++ b/generated/googleapis/lib/servicedirectory/v1.dart
@@ -1405,7 +1405,7 @@ class Endpoint {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -1643,14 +1643,14 @@ class Namespace {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/servicemanagement/v1.dart
+++ b/generated/googleapis/lib/servicemanagement/v1.dart
@@ -2091,14 +2091,14 @@ class Diagnostic {
 
 /// `Documentation` provides the information for describing a service.
 ///
-/// Example: documentation: summary: > The Google Calendar API gives access to
+/// Example: documentation: summary: \> The Google Calendar API gives access to
 /// most calendar features. pages: - name: Overview content: (== include
 /// google/foo/overview.md ==) - name: Tutorial content: (== include
 /// google/foo/tutorial.md ==) subpages; - name: Java content: (== include
 /// google/foo/tutorial_java.md ==) rules: - selector:
-/// google.calendar.Calendar.Get description: > ... - selector:
-/// google.calendar.Calendar.Put description: > ... Documentation is provided in
-/// markdown syntax. In addition to standard markdown features, definition
+/// google.calendar.Calendar.Get description: \> ... - selector:
+/// google.calendar.Calendar.Put description: \> ... Documentation is provided
+/// in markdown syntax. In addition to standard markdown features, definition
 /// lists, tables and fenced code blocks are supported. Section headers can be
 /// provided and are interpreted relative to the section nesting of the context
 /// where a documentation fragment is embedded. Documentation from the IDL is
@@ -2327,7 +2327,7 @@ class EnumValue {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -4048,14 +4048,14 @@ class Page {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/servicenetworking/v1.dart
+++ b/generated/googleapis/lib/servicenetworking/v1.dart
@@ -2553,14 +2553,14 @@ class DnsZone {
 
 /// `Documentation` provides the information for describing a service.
 ///
-/// Example: documentation: summary: > The Google Calendar API gives access to
+/// Example: documentation: summary: \> The Google Calendar API gives access to
 /// most calendar features. pages: - name: Overview content: (== include
 /// google/foo/overview.md ==) - name: Tutorial content: (== include
 /// google/foo/tutorial.md ==) subpages; - name: Java content: (== include
 /// google/foo/tutorial_java.md ==) rules: - selector:
-/// google.calendar.Calendar.Get description: > ... - selector:
-/// google.calendar.Calendar.Put description: > ... Documentation is provided in
-/// markdown syntax. In addition to standard markdown features, definition
+/// google.calendar.Calendar.Get description: \> ... - selector:
+/// google.calendar.Calendar.Put description: \> ... Documentation is provided
+/// in markdown syntax. In addition to standard markdown features, definition
 /// lists, tables and fenced code blocks are supported. Section headers can be
 /// provided and are interpreted relative to the section nesting of the context
 /// where a documentation fragment is embedded. Documentation from the IDL is

--- a/generated/googleapis/lib/serviceusage/v1.dart
+++ b/generated/googleapis/lib/serviceusage/v1.dart
@@ -1356,14 +1356,14 @@ class DisableServiceResponse {
 
 /// `Documentation` provides the information for describing a service.
 ///
-/// Example: documentation: summary: > The Google Calendar API gives access to
+/// Example: documentation: summary: \> The Google Calendar API gives access to
 /// most calendar features. pages: - name: Overview content: (== include
 /// google/foo/overview.md ==) - name: Tutorial content: (== include
 /// google/foo/tutorial.md ==) subpages; - name: Java content: (== include
 /// google/foo/tutorial_java.md ==) rules: - selector:
-/// google.calendar.Calendar.Get description: > ... - selector:
-/// google.calendar.Calendar.Put description: > ... Documentation is provided in
-/// markdown syntax. In addition to standard markdown features, definition
+/// google.calendar.Calendar.Get description: \> ... - selector:
+/// google.calendar.Calendar.Put description: \> ... Documentation is provided
+/// in markdown syntax. In addition to standard markdown features, definition
 /// lists, tables and fenced code blocks are supported. Section headers can be
 /// provided and are interpreted relative to the section nesting of the context
 /// where a documentation fragment is embedded. Documentation from the IDL is

--- a/generated/googleapis/lib/shared.dart
+++ b/generated/googleapis/lib/shared.dart
@@ -9593,8 +9593,8 @@ class $ListPolicy {
   /// allowed_values: "E2"} `projects/bar` has a `Policy` with: {all: DENY} The
   /// accepted values at `organizations/foo` are `E1`, E2`. No value is accepted
   /// at `projects/bar`. Example 10 (allowed and denied subtrees of Resource
-  /// Manager hierarchy): Given the following resource hierarchy O1->{F1, F2};
-  /// F1->{P1}; F2->{P2, P3}, `organizations/foo` has a `Policy` with values:
+  /// Manager hierarchy): Given the following resource hierarchy O1-\>{F1, F2};
+  /// F1-\>{P1}; F2-\>{P2, P3}, `organizations/foo` has a `Policy` with values:
   /// {allowed_values: "under:organizations/O1"} `projects/bar` has a `Policy`
   /// with: {allowed_values: "under:projects/P3"} {denied_values:
   /// "under:folders/F2"} The accepted values at `organizations/foo` are
@@ -14618,7 +14618,7 @@ class $Resource01 {
 
   /// Mutable.
   ///
-  /// The display name set by clients. Must be <= 63 characters.
+  /// The display name set by clients. Must be \<= 63 characters.
   core.String? displayName;
 
   /// An opaque value that uniquely identifies a version or generation of a
@@ -17390,7 +17390,7 @@ class $TraceSamplingConfig {
   /// Field sampling rate.
   ///
   /// This value is only applicable when using the PROBABILITY sampler. The
-  /// supported values are > 0 and <= 0.5.
+  /// supported values are \> 0 and \<= 0.5.
   core.double? samplingRate;
 
   $TraceSamplingConfig({
@@ -17659,7 +17659,7 @@ class $UserDefinedVariableConfiguration {
   /// User-friendly name for the variable which will appear in reports.
   ///
   /// This is a required field, must be less than 64 characters long, and cannot
-  /// contain the following characters: ""<>".
+  /// contain the following characters: ""\<\>".
   core.String? reportName;
 
   /// Variable name in the tag.

--- a/generated/googleapis/lib/sheets/v4.dart
+++ b/generated/googleapis/lib/sheets/v4.dart
@@ -4291,19 +4291,19 @@ class CellFormat {
   /// written in the next cell over, so long as that cell is empty. If the next
   /// cell over is non-empty, this behaves the same as `CLIP`. The text will
   /// never wrap to the next line unless the user manually inserts a new line.
-  /// Example: | First sentence. | | Manual newline that is very long. <- Text
+  /// Example: | First sentence. | | Manual newline that is very long. \<- Text
   /// continues into next cell | Next newline. |
   /// - "LEGACY_WRAP" : This wrap strategy represents the old Google Sheets wrap
   /// strategy where words that are longer than a line are clipped rather than
   /// broken. This strategy is not supported on all platforms and is being
-  /// phased out. Example: | Cell has a | | loooooooooo| <- Word is clipped. |
+  /// phased out. Example: | Cell has a | | loooooooooo| \<- Word is clipped. |
   /// word. |
   /// - "CLIP" : Lines that are longer than the cell width will be clipped. The
   /// text will never wrap to the next line unless the user manually inserts a
-  /// new line. Example: | First sentence. | | Manual newline t| <- Text is
+  /// new line. Example: | First sentence. | | Manual newline t| \<- Text is
   /// clipped | Next newline. |
   /// - "WRAP" : Words that are longer than a line are wrapped at the character
-  /// level rather than clipped. Example: | Cell has a | | loooooooooo| <- Word
+  /// level rather than clipped. Example: | Cell has a | | loooooooooo| \<- Word
   /// is broken. | ong word. |
   core.String? wrapStrategy;
 
@@ -5062,7 +5062,7 @@ class ClearValuesResponse {
 /// toProto(UIColor* color) { CGFloat red, green, blue, alpha; if (!\[color
 /// getRed:&red green:&green blue:&blue alpha:&alpha\]) { return nil; } Color*
 /// result = \[\[Color alloc\] init\]; \[result setRed:red\]; \[result
-/// setGreen:green\]; \[result setBlue:blue\]; if (alpha <= 0.9999) { \[result
+/// setGreen:green\]; \[result setBlue:blue\]; if (alpha \<= 0.9999) { \[result
 /// setAlpha:floatWrapperWithValue(alpha)\]; } \[result autorelease\]; return
 /// result; } // ... Example (JavaScript): // ... var protoToCssColor =
 /// function(rgb_color) { var redFrac = rgb_color.red || 0.0; var greenFrac =
@@ -5072,10 +5072,10 @@ class ClearValuesResponse {
 /// rgbToCssColor(red, green, blue); } var alphaFrac = rgb_color.alpha.value ||
 /// 0.0; var rgbParams = \[red, green, blue\].join(','); return \['rgba(',
 /// rgbParams, ',', alphaFrac, ')'\].join(''); }; var rgbToCssColor =
-/// function(red, green, blue) { var rgbNumber = new Number((red << 16) | (green
-/// << 8) | blue); var hexString = rgbNumber.toString(16); var missingZeros = 6
-/// - hexString.length; var resultBuilder = \['#'\]; for (var i = 0; i <
-/// missingZeros; i++) { resultBuilder.push('0'); }
+/// function(red, green, blue) { var rgbNumber = new Number((red \<\< 16) |
+/// (green \<\< 8) | blue); var hexString = rgbNumber.toString(16); var
+/// missingZeros = 6 - hexString.length; var resultBuilder = \['#'\]; for (var i
+/// = 0; i \< missingZeros; i++) { resultBuilder.push('0'); }
 /// resultBuilder.push(hexString); return resultBuilder.join(''); }; // ...
 typedef Color = $Color;
 
@@ -8048,7 +8048,7 @@ class FindReplaceResponse {
   /// The number of occurrences (possibly multiple within a cell) changed.
   ///
   /// For example, if replacing `"e"` with `"o"` in `"Google Sheets"`, this
-  /// would be `"3"` because `"Google Sheets"` -> `"Googlo Shoots"`.
+  /// would be `"3"` because `"Google Sheets"` -\> `"Googlo Shoots"`.
   core.int? occurrencesChanged;
 
   /// The number of rows changed.
@@ -8520,8 +8520,8 @@ class HistogramChartSpec {
 /// looks like the one below by applying a histogram group rule with a
 /// HistogramRule.start of 25, an HistogramRule.interval of 20, and an
 /// HistogramRule.end of 65. +-------------+-------------------+ | Grouped Age |
-/// AVERAGE of Amount | +-------------+-------------------+ | < 25 | $19.34 | |
-/// 25-45 | $31.43 | | 45-65 | $35.87 | | > 65 | $27.55 |
+/// AVERAGE of Amount | +-------------+-------------------+ | \< 25 | $19.34 | |
+/// 25-45 | $31.43 | | 45-65 | $35.87 | | \> 65 | $27.55 |
 /// +-------------+-------------------+ | Grand Total | $29.12 |
 /// +-------------+-------------------+
 class HistogramRule {
@@ -9572,7 +9572,7 @@ class PivotFilterCriteria {
   /// pivot table can be referenced by column header name. For example, if the
   /// source data has columns named "Revenue" and "Cost" and a condition is
   /// applied to the "Revenue" column with type `NUMBER_GREATER` and value
-  /// `=Cost`, then only columns where "Revenue" > "Cost" are included.
+  /// `=Cost`, then only columns where "Revenue" \> "Cost" are included.
   BooleanCondition? condition;
 
   /// Whether values are visible by default.

--- a/generated/googleapis/lib/sourcerepo/v1.dart
+++ b/generated/googleapis/lib/sourcerepo/v1.dart
@@ -706,7 +706,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -897,14 +897,14 @@ class Operation {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis/lib/spanner/v1.dart
+++ b/generated/googleapis/lib/spanner/v1.dart
@@ -394,12 +394,12 @@ class ProjectsInstancesResource {
   /// [filter] - An expression for filtering the results of the request. Filter
   /// rules are case insensitive. The fields eligible for filtering are: *
   /// `name` * `display_name` * `labels.key` where key is the name of a label
-  /// Some examples of using filters are: * `name:*` --> The instance has a
-  /// name. * `name:Howl` --> The instance's name contains the string "howl". *
-  /// `name:HOWL` --> Equivalent to above. * `NAME:howl` --> Equivalent to
-  /// above. * `labels.env:*` --> The instance has the label "env". *
-  /// `labels.env:dev` --> The instance has the label "env" and the value of the
-  /// label contains the string "dev". * `name:howl labels.env:dev` --> The
+  /// Some examples of using filters are: * `name:*` --\> The instance has a
+  /// name. * `name:Howl` --\> The instance's name contains the string "howl". *
+  /// `name:HOWL` --\> Equivalent to above. * `NAME:howl` --\> Equivalent to
+  /// above. * `labels.env:*` --\> The instance has the label "env". *
+  /// `labels.env:dev` --\> The instance has the label "env" and the value of
+  /// the label contains the string "dev". * `name:howl labels.env:dev` --\> The
   /// instance's name contains "howl" and it has the label "env" with its value
   /// containing "dev".
   ///
@@ -2596,8 +2596,8 @@ class ProjectsInstancesDatabasesSessionsResource {
   /// [filter] - An expression for filtering the results of the request. Filter
   /// rules are case insensitive. The fields eligible for filtering are: *
   /// `labels.key` where key is the name of a label Some examples of using
-  /// filters are: * `labels.env:*` --> The session has the label "env". *
-  /// `labels.env:dev` --> The session has the label "env" and the value of the
+  /// filters are: * `labels.env:*` --\> The session has the label "env". *
+  /// `labels.env:dev` --\> The session has the label "env" and the value of the
   /// label contains the string "dev".
   ///
   /// [pageSize] - Number of sessions to be returned in the response. If 0 or
@@ -4674,7 +4674,7 @@ class ExecuteSqlRequest {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -6126,18 +6126,18 @@ class PartialResultSet {
   /// list by applying these rules recursively. * `object`: concatenate the
   /// (field name, field value) pairs. If a field name is duplicated, then apply
   /// these rules recursively to merge the field values. Some examples of
-  /// merging: # Strings are concatenated. "foo", "bar" => "foobar" # Lists of
-  /// non-strings are concatenated. \[2, 3\], \[4\] => \[2, 3, 4\] # Lists are
+  /// merging: # Strings are concatenated. "foo", "bar" =\> "foobar" # Lists of
+  /// non-strings are concatenated. \[2, 3\], \[4\] =\> \[2, 3, 4\] # Lists are
   /// concatenated, but the last and first elements are merged # because they
-  /// are strings. \["a", "b"\], \["c", "d"\] => \["a", "bc", "d"\] # Lists are
+  /// are strings. \["a", "b"\], \["c", "d"\] =\> \["a", "bc", "d"\] # Lists are
   /// concatenated, but the last and first elements are merged # because they
   /// are lists. Recursively, the last and first elements # of the inner lists
   /// are merged because they are strings. \["a", \["b", "c"\]\], \[\["d"\],
-  /// "e"\] => \["a", \["b", "cd"\], "e"\] # Non-overlapping object fields are
-  /// combined. {"a": "1"}, {"b": "2"} => {"a": "1", "b": 2"} # Overlapping
-  /// object fields are merged. {"a": "1"}, {"a": "2"} => {"a": "12"} # Examples
-  /// of merging objects containing lists of strings. {"a": \["1"\]}, {"a":
-  /// \["2"\]} => {"a": \["12"\]} For a more complete example, suppose a
+  /// "e"\] =\> \["a", \["b", "cd"\], "e"\] # Non-overlapping object fields are
+  /// combined. {"a": "1"}, {"b": "2"} =\> {"a": "1", "b": 2"} # Overlapping
+  /// object fields are merged. {"a": "1"}, {"a": "2"} =\> {"a": "12"} #
+  /// Examples of merging objects containing lists of strings. {"a": \["1"\]},
+  /// {"a": \["2"\]} =\> {"a": \["12"\]} For a more complete example, suppose a
   /// streaming SQL query is yielding a result set whose rows contain a single
   /// string field. The following `PartialResultSet`s might be yielded: {
   /// "metadata": { ... } "values": \["Hello", "W"\] "chunked_value": true
@@ -6581,14 +6581,14 @@ class PlanNode {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {
@@ -6816,7 +6816,7 @@ class ReadOnly {
   /// without the distributed timestamp negotiation overhead of `max_staleness`.
   core.String? exactStaleness;
 
-  /// Read data at a timestamp >= `NOW - max_staleness` seconds.
+  /// Read data at a timestamp \>= `NOW - max_staleness` seconds.
   ///
   /// Guarantees that all writes that have committed more than the specified
   /// number of seconds ago are visible. Because Cloud Spanner chooses the exact
@@ -6827,7 +6827,7 @@ class ReadOnly {
   /// this option can only be used in single-use transactions.
   core.String? maxStaleness;
 
-  /// Executes all reads at a timestamp >= `min_read_timestamp`.
+  /// Executes all reads at a timestamp \>= `min_read_timestamp`.
   ///
   /// This is useful for requesting fresher data than some previous read, or
   /// data that is fresh enough to observe the effects of some previously
@@ -7754,7 +7754,7 @@ class ShortRepresentation {
   /// A string representation of the expression subtree rooted at this node.
   core.String? description;
 
-  /// A mapping of (subquery variable name) -> (subquery node id) for cases
+  /// A mapping of (subquery variable name) -\> (subquery node id) for cases
   /// where the `description` string of this node references a `SCALAR` subquery
   /// contained in the expression subtree rooted at this node.
   ///
@@ -8055,7 +8055,7 @@ class Transaction {
 /// less than or equal to the read timestamp, and observe none of the
 /// modifications done by transactions with a larger commit timestamp. They will
 /// block until all conflicting transactions that may be assigned commit
-/// timestamps <= the read timestamp have finished. The timestamp can either be
+/// timestamps \<= the read timestamp have finished. The timestamp can either be
 /// expressed as an absolute Cloud Spanner commit timestamp or a staleness
 /// relative to the current time. These modes do not require a "negotiation
 /// phase" to pick a timestamp. As a result, they execute slightly faster than

--- a/generated/googleapis/lib/speech/v1.dart
+++ b/generated/googleapis/lib/speech/v1.dart
@@ -589,8 +589,8 @@ class RecognitionConfig {
   /// value does not add punctuation to result hypotheses.
   core.bool? enableAutomaticPunctuation;
 
-  /// This needs to be set to `true` explicitly and `audio_channel_count` > 1 to
-  /// get each channel recognized separately.
+  /// This needs to be set to `true` explicitly and `audio_channel_count` \> 1
+  /// to get each channel recognized separately.
   ///
   /// The recognition result will contain a `channel_tag` field to state which
   /// channel that result belongs to. If this is not true, we will only

--- a/generated/googleapis/lib/storage/v1.dart
+++ b/generated/googleapis/lib/storage/v1.dart
@@ -5224,7 +5224,7 @@ class ComposeRequest {
 /// Represents an expression text.
 ///
 /// Example: title: "User account presence" description: "Determines whether the
-/// request has a user account" expression: "size(request.user) > 0"
+/// request has a user account" expression: "size(request.user) \> 0"
 class Expr {
   /// An optional description of the expression.
   ///

--- a/generated/googleapis/lib/streetviewpublish/v1.dart
+++ b/generated/googleapis/lib/streetviewpublish/v1.dart
@@ -1162,7 +1162,7 @@ class Pose {
   /// Compass heading, measured at the center of the photo in degrees clockwise
   /// from North.
   ///
-  /// Value must be >=0 and <360. NaN indicates an unmeasured quantity.
+  /// Value must be \>=0 and \<360. NaN indicates an unmeasured quantity.
   core.double? heading;
 
   /// Latitude and longitude pair of the pose, as explained here:
@@ -1179,14 +1179,14 @@ class Pose {
 
   /// Pitch, measured at the center of the photo in degrees.
   ///
-  /// Value must be >=-90 and <= 90. A value of -90 means looking directly down,
-  /// and a value of 90 means looking directly up. NaN indicates an unmeasured
-  /// quantity.
+  /// Value must be \>=-90 and \<= 90. A value of -90 means looking directly
+  /// down, and a value of 90 means looking directly up. NaN indicates an
+  /// unmeasured quantity.
   core.double? pitch;
 
   /// Roll, measured in degrees.
   ///
-  /// Value must be >= 0 and <360. A value of 0 means level with the horizon.
+  /// Value must be \>= 0 and \<360. A value of 0 means level with the horizon.
   /// NaN indicates an unmeasured quantity.
   core.double? roll;
 

--- a/generated/googleapis/lib/sts/v1.dart
+++ b/generated/googleapis/lib/sts/v1.dart
@@ -887,7 +887,7 @@ class GoogleIdentityStsV1betaOptions {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"

--- a/generated/googleapis/lib/tasks/v1.dart
+++ b/generated/googleapis/lib/tasks/v1.dart
@@ -700,7 +700,7 @@ class TasksResource {
 class TaskLinks {
   /// The description.
   ///
-  /// In HTML speak: Everything between <a> and </a>.
+  /// In HTML speak: Everything between \<a\> and \</a\>.
   core.String? description;
 
   /// The URL.

--- a/generated/googleapis/lib/testing/v1.dart
+++ b/generated/googleapis/lib/testing/v1.dart
@@ -2461,8 +2461,8 @@ class ManualSharding {
   /// Group of packages, classes, and/or test methods to be run for each shard.
   ///
   /// When any physical devices are selected, the number of
-  /// test_targets_for_shard must be >= 1 and <= 50. When no physical devices
-  /// are selected, the number must be >= 1 and <= 500.
+  /// test_targets_for_shard must be \>= 1 and \<= 50. When no physical devices
+  /// are selected, the number must be \>= 1 and \<= 500.
   ///
   /// Required.
   core.List<TestTargetsForShard>? testTargetsForShard;
@@ -3912,7 +3912,7 @@ class TrafficRule {
   /// Burst size in kbits.
   core.double? burst;
 
-  /// Packet delay, must be >= 0.
+  /// Packet delay, must be \>= 0.
   core.String? delay;
 
   /// Packet duplication ratio (0.0 - 1.0).
@@ -3965,8 +3965,9 @@ class TrafficRule {
 class UniformSharding {
   /// Total number of shards.
   ///
-  /// When any physical devices are selected, the number must be >= 1 and <= 50.
-  /// When no physical devices are selected, the number must be >= 1 and <= 500.
+  /// When any physical devices are selected, the number must be \>= 1 and \<=
+  /// 50. When no physical devices are selected, the number must be \>= 1 and
+  /// \<= 500.
   ///
   /// Required.
   core.int? numShards;

--- a/generated/googleapis/lib/texttospeech/v1.dart
+++ b/generated/googleapis/lib/texttospeech/v1.dart
@@ -209,7 +209,7 @@ class AudioConfig {
   /// Speaking rate/speed, in the range \[0.25, 4.0\]. 1.0 is the normal native
   /// speed supported by the specific voice. 2.0 is twice as fast, and 0.5 is
   /// half as fast. If unset(0.0), defaults to the native 1.0 speed. Any other
-  /// values < 0.25 or > 4.0 will return an error.
+  /// values \< 0.25 or \> 4.0 will return an error.
   ///
   /// Optional.
   core.double? speakingRate;

--- a/generated/googleapis/lib/translate/v3.dart
+++ b/generated/googleapis/lib/translate/v3.dart
@@ -982,8 +982,9 @@ class BatchTranslateTextRequest {
 
   /// Input configurations.
   ///
-  /// The total number of files matched should be <= 100. The total content size
-  /// should be <= 100M Unicode codepoints. The files must use UTF-8 encoding.
+  /// The total number of files matched should be \<= 100. The total content
+  /// size should be \<= 100M Unicode codepoints. The files must use UTF-8
+  /// encoding.
   ///
   /// Required.
   core.List<InputConfig>? inputConfigs;
@@ -1426,7 +1427,7 @@ class InputConfig {
   /// column (optional) is the id of the text request. If the first column is
   /// missing, we use the row number (0-based) from the input file as the ID in
   /// the output file. The second column is the actual text to be translated. We
-  /// recommend each row be <= 10K Unicode codepoints, otherwise an error might
+  /// recommend each row be \<= 10K Unicode codepoints, otherwise an error might
   /// be returned. Note that the input tsv must be RFC 4180 compliant. You could
   /// use https://github.com/Clever/csvlint to check potential formatting errors
   /// in your tsv file. csvlint --delimiter='\t' your_input_file.tsv The other

--- a/generated/googleapis/lib/vectortile/v1.dart
+++ b/generated/googleapis/lib/vectortile/v1.dart
@@ -800,8 +800,8 @@ class FeatureTile {
 /// (generally) relative to the EGM96 geoid, however some areas will be relative
 /// to NAVD88. EGM96 and NAVD88 are off by no more than 2 meters. The grid is
 /// oriented north-west to south-east, as illustrated: rows\[0\].a\[0\]
-/// rows\[0\].a\[m\] +-----------------+ | | | N | | ^ | | | | | W <-----> E | |
-/// | | | v | | S | | | +-----------------+ rows\[n\].a\[0\] rows\[n\].a\[m\]
+/// rows\[0\].a\[m\] +-----------------+ | | | N | | ^ | | | | | W \<-----\> E |
+/// | | | | v | | S | | | +-----------------+ rows\[n\].a\[0\] rows\[n\].a\[m\]
 /// Rather than storing the altitudes directly, we store the diffs between them
 /// as integers at some requested level of precision to take advantage of
 /// integer packing. The actual altitude values a\[\] can be reconstructed using
@@ -1104,7 +1104,7 @@ class Row {
   /// units are specified by the altitude_multiplier parameter above; the value
   /// in meters is given by altitude_multiplier * altitude_diffs\[n\]. The
   /// altitude row (in metres above sea level) can be reconstructed with: a\[0\]
-  /// = altitude_diffs\[0\] * altitude_multiplier when n > 0, a\[n\] = a\[n-1\]
+  /// = altitude_diffs\[0\] * altitude_multiplier when n \> 0, a\[n\] = a\[n-1\]
   /// + altitude_diffs\[n-1\] * altitude_multiplier.
   core.List<core.int>? altitudeDiffs;
 
@@ -1134,8 +1134,8 @@ class Row {
 /// (generally) relative to the EGM96 geoid, however some areas will be relative
 /// to NAVD88. EGM96 and NAVD88 are off by no more than 2 meters. The grid is
 /// oriented north-west to south-east, as illustrated: rows\[0\].a\[0\]
-/// rows\[0\].a\[m\] +-----------------+ | | | N | | ^ | | | | | W <-----> E | |
-/// | | | v | | S | | | +-----------------+ rows\[n\].a\[0\] rows\[n\].a\[m\]
+/// rows\[0\].a\[m\] +-----------------+ | | | N | | ^ | | | | | W \<-----\> E |
+/// | | | | v | | S | | | +-----------------+ rows\[n\].a\[0\] rows\[n\].a\[m\]
 /// Rather than storing the altitudes directly, we store the diffs of the diffs
 /// between them as integers at some requested level of precision to take
 /// advantage of integer packing. Note that the data is packed in such a way

--- a/generated/googleapis/lib/vision/v1.dart
+++ b/generated/googleapis/lib/vision/v1.dart
@@ -2882,7 +2882,7 @@ typedef CancelOperationRequest = $Empty;
 /// toProto(UIColor* color) { CGFloat red, green, blue, alpha; if (!\[color
 /// getRed:&red green:&green blue:&blue alpha:&alpha\]) { return nil; } Color*
 /// result = \[\[Color alloc\] init\]; \[result setRed:red\]; \[result
-/// setGreen:green\]; \[result setBlue:blue\]; if (alpha <= 0.9999) { \[result
+/// setGreen:green\]; \[result setBlue:blue\]; if (alpha \<= 0.9999) { \[result
 /// setAlpha:floatWrapperWithValue(alpha)\]; } \[result autorelease\]; return
 /// result; } // ... Example (JavaScript): // ... var protoToCssColor =
 /// function(rgb_color) { var redFrac = rgb_color.red || 0.0; var greenFrac =
@@ -2892,10 +2892,10 @@ typedef CancelOperationRequest = $Empty;
 /// rgbToCssColor(red, green, blue); } var alphaFrac = rgb_color.alpha.value ||
 /// 0.0; var rgbParams = \[red, green, blue\].join(','); return \['rgba(',
 /// rgbParams, ',', alphaFrac, ')'\].join(''); }; var rgbToCssColor =
-/// function(red, green, blue) { var rgbNumber = new Number((red << 16) | (green
-/// << 8) | blue); var hexString = rgbNumber.toString(16); var missingZeros = 6
-/// - hexString.length; var resultBuilder = \['#'\]; for (var i = 0; i <
-/// missingZeros; i++) { resultBuilder.push('0'); }
+/// function(red, green, blue) { var rgbNumber = new Number((red \<\< 16) |
+/// (green \<\< 8) | blue); var hexString = rgbNumber.toString(16); var
+/// missingZeros = 6 - hexString.length; var resultBuilder = \['#'\]; for (var i
+/// = 0; i \< missingZeros; i++) { resultBuilder.push('0'); }
 /// resultBuilder.push(hexString); return resultBuilder.join(''); }; // ...
 typedef Color = $Color;
 
@@ -5057,7 +5057,7 @@ class GoogleCloudVisionV1p1beta1Symbol {
 /// TextAnnotation contains a structured representation of OCR extracted text.
 ///
 /// The hierarchy of an OCR extracted text structure is like this:
-/// TextAnnotation -> Page -> Block -> Paragraph -> Word -> Symbol Each
+/// TextAnnotation -\> Page -\> Block -\> Paragraph -\> Word -\> Symbol Each
 /// structural component, starting from Page, may further have their own
 /// properties. Properties describe detected languages, breaks etc.. Please
 /// refer to the TextAnnotation.TextProperty message definition below for more
@@ -6953,7 +6953,7 @@ class GoogleCloudVisionV1p2beta1Symbol {
 /// TextAnnotation contains a structured representation of OCR extracted text.
 ///
 /// The hierarchy of an OCR extracted text structure is like this:
-/// TextAnnotation -> Page -> Block -> Paragraph -> Word -> Symbol Each
+/// TextAnnotation -\> Page -\> Block -\> Paragraph -\> Word -\> Symbol Each
 /// structural component, starting from Page, may further have their own
 /// properties. Properties describe detected languages, breaks etc.. Please
 /// refer to the TextAnnotation.TextProperty message definition below for more
@@ -8954,7 +8954,7 @@ class GoogleCloudVisionV1p3beta1Symbol {
 /// TextAnnotation contains a structured representation of OCR extracted text.
 ///
 /// The hierarchy of an OCR extracted text structure is like this:
-/// TextAnnotation -> Page -> Block -> Paragraph -> Word -> Symbol Each
+/// TextAnnotation -\> Page -\> Block -\> Paragraph -\> Word -\> Symbol Each
 /// structural component, starting from Page, may further have their own
 /// properties. Properties describe detected languages, breaks etc.. Please
 /// refer to the TextAnnotation.TextProperty message definition below for more
@@ -11089,7 +11089,7 @@ class GoogleCloudVisionV1p4beta1Symbol {
 /// TextAnnotation contains a structured representation of OCR extracted text.
 ///
 /// The hierarchy of an OCR extracted text structure is like this:
-/// TextAnnotation -> Page -> Block -> Paragraph -> Word -> Symbol Each
+/// TextAnnotation -\> Page -\> Block -\> Paragraph -\> Word -\> Symbol Each
 /// structural component, starting from Page, may further have their own
 /// properties. Properties describe detected languages, breaks etc.. Please
 /// refer to the TextAnnotation.TextProperty message definition below for more
@@ -12977,7 +12977,7 @@ class Symbol {
 /// TextAnnotation contains a structured representation of OCR extracted text.
 ///
 /// The hierarchy of an OCR extracted text structure is like this:
-/// TextAnnotation -> Page -> Block -> Paragraph -> Word -> Symbol Each
+/// TextAnnotation -\> Page -\> Block -\> Paragraph -\> Word -\> Symbol Each
 /// structural component, starting from Page, may further have their own
 /// properties. Properties describe detected languages, breaks etc.. Please
 /// refer to the TextAnnotation.TextProperty message definition below for more

--- a/generated/googleapis/lib/youtube/v3.dart
+++ b/generated/googleapis/lib/youtube/v3.dart
@@ -13813,7 +13813,7 @@ class PlaylistLocalization {
 }
 
 class PlaylistPlayer {
-  /// An <iframe> tag that embeds a player that will play the playlist.
+  /// An \<iframe\> tag that embeds a player that will play the playlist.
   core.String? embedHtml;
 
   PlaylistPlayer({
@@ -16540,7 +16540,7 @@ class VideoMonetizationDetails {
 class VideoPlayer {
   core.String? embedHeight;
 
-  /// An <iframe> tag that embeds a player that will play the video.
+  /// An \<iframe\> tag that embeds a player that will play the video.
   core.String? embedHtml;
 
   /// The embed width
@@ -17305,8 +17305,8 @@ class VideoTopicDetails {
   ///
   /// These are topics that are centrally featured in the video, and it can be
   /// said that the video is mainly about each of these. You can retrieve
-  /// information about each topic using the < a
-  /// href="http://wiki.freebase.com/wiki/Topic_API">Freebase Topic API.
+  /// information about each topic using the \< a
+  /// href="http://wiki.freebase.com/wiki/Topic_API"\>Freebase Topic API.
   core.List<core.String>? topicIds;
 
   VideoTopicDetails({

--- a/generated/googleapis_beta/lib/adexchangebuyer2/v2beta1.dart
+++ b/generated/googleapis_beta/lib/adexchangebuyer2/v2beta1.dart
@@ -9023,8 +9023,8 @@ class RealtimeTimeRange {
 /// A relative date range, specified by an offset and a duration.
 ///
 /// The supported range of dates begins 30 days before today and ends today,
-/// i.e., the limits for these values are: offset_days >= 0 duration_days >= 1
-/// offset_days + duration_days <= 30
+/// i.e., the limits for these values are: offset_days \>= 0 duration_days \>= 1
+/// offset_days + duration_days \<= 30
 class RelativeDateRange {
   /// The number of days in the requested date range, e.g., for a range spanning
   /// today: 1.

--- a/generated/googleapis_beta/lib/alertcenter/v1beta1.dart
+++ b/generated/googleapis_beta/lib/alertcenter/v1beta1.dart
@@ -751,7 +751,7 @@ class ActivityRule {
   /// this alert and we found the relationship after creating both alerts.
   core.String? supersedingAlert;
 
-  /// Alert threshold is for example “COUNT > 5”.
+  /// Alert threshold is for example “COUNT \> 5”.
   core.String? threshold;
 
   /// The trigger sources for this rule.

--- a/generated/googleapis_beta/lib/analyticsdata/v1beta.dart
+++ b/generated/googleapis_beta/lib/analyticsdata/v1beta.dart
@@ -1269,12 +1269,13 @@ class DimensionOrderBy {
   /// Possible string values are:
   /// - "ORDER_TYPE_UNSPECIFIED" : Unspecified.
   /// - "ALPHANUMERIC" : Alphanumeric sort by Unicode code point. For example,
-  /// "2" < "A" < "X" < "b" < "z".
+  /// "2" \< "A" \< "X" \< "b" \< "z".
   /// - "CASE_INSENSITIVE_ALPHANUMERIC" : Case insensitive alphanumeric sort by
-  /// lower case Unicode code point. For example, "2" < "A" < "b" < "X" < "z".
+  /// lower case Unicode code point. For example, "2" \< "A" \< "b" \< "X" \<
+  /// "z".
   /// - "NUMERIC" : Dimension values are converted to numbers before sorting.
-  /// For example in NUMERIC sort, "25" < "100", and in `ALPHANUMERIC` sort,
-  /// "100" < "25". Non-numeric dimension values all have equal ordering value
+  /// For example in NUMERIC sort, "25" \< "100", and in `ALPHANUMERIC` sort,
+  /// "100" \< "25". Non-numeric dimension values all have equal ordering value
   /// below all numeric values.
   core.String? orderType;
 

--- a/generated/googleapis_beta/lib/bigqueryconnection/v1beta1.dart
+++ b/generated/googleapis_beta/lib/bigqueryconnection/v1beta1.dart
@@ -818,7 +818,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -911,14 +911,14 @@ class ListConnectionsResponse {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis_beta/lib/containeranalysis/v1beta1.dart
+++ b/generated/googleapis_beta/lib/containeranalysis/v1beta1.dart
@@ -2733,7 +2733,7 @@ typedef Environment = $Shared02;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -4962,14 +4962,14 @@ class PgpSignedAttestation {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis_beta/lib/datacatalog/v1beta1.dart
+++ b/generated/googleapis_beta/lib/datacatalog/v1beta1.dart
@@ -2964,7 +2964,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -3924,7 +3924,7 @@ class GoogleCloudDatacatalogV1beta1ListTaxonomiesResponse {
 /// Denotes one policy tag in a taxonomy (e.g. ssn).
 ///
 /// Policy Tags can be defined in a hierarchy. For example, consider the
-/// following hierarchy: Geolocation -> (LatLong, City, ZipCode). PolicyTag
+/// following hierarchy: Geolocation -\> (LatLong, City, ZipCode). PolicyTag
 /// "Geolocation" contains three child policy tags: "LatLong", "City", and
 /// "ZipCode".
 class GoogleCloudDatacatalogV1beta1PolicyTag {
@@ -4094,8 +4094,8 @@ class GoogleCloudDatacatalogV1beta1SearchCatalogRequest {
 
   /// Number of results in the search page.
   ///
-  /// If <=0 then defaults to 10. Max limit for page_size is 1000. Throws an
-  /// invalid argument for page_size > 1000.
+  /// If \<=0 then defaults to 10. Max limit for page_size is 1000. Throws an
+  /// invalid argument for page_size \> 1000.
   core.int? pageSize;
 
   /// Pagination token returned in an earlier
@@ -5125,14 +5125,14 @@ class GoogleCloudDatacatalogV1beta1ViewSpec {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis_beta/lib/dataflow/v1b3.dart
+++ b/generated/googleapis_beta/lib/dataflow/v1b3.dart
@@ -791,14 +791,15 @@ class ProjectsJobsMessagesResource {
   ///
   /// [jobId] - The job to get messages about.
   ///
-  /// [endTime] - Return only messages with timestamps < end_time. The default
+  /// [endTime] - Return only messages with timestamps \< end_time. The default
   /// is now (i.e. return up to the latest messages available).
   ///
   /// [location] - The
   /// [regional endpoint](https://cloud.google.com/dataflow/docs/concepts/regional-endpoints)
   /// that contains the job specified by job_id.
   ///
-  /// [minimumImportance] - Filter to only get messages with importance >= level
+  /// [minimumImportance] - Filter to only get messages with importance \>=
+  /// level
   /// Possible string values are:
   /// - "JOB_MESSAGE_IMPORTANCE_UNKNOWN" : The message importance isn't
   /// specified, or is unknown.
@@ -832,7 +833,7 @@ class ProjectsJobsMessagesResource {
   /// returned by an earlier call. This will cause the next page of results to
   /// be returned.
   ///
-  /// [startTime] - If specified, return only messages with timestamps >=
+  /// [startTime] - If specified, return only messages with timestamps \>=
   /// start_time. The default is the job creation time (i.e. beginning of
   /// messages).
   ///
@@ -1731,10 +1732,11 @@ class ProjectsLocationsJobsMessagesResource {
   ///
   /// [jobId] - The job to get messages about.
   ///
-  /// [endTime] - Return only messages with timestamps < end_time. The default
+  /// [endTime] - Return only messages with timestamps \< end_time. The default
   /// is now (i.e. return up to the latest messages available).
   ///
-  /// [minimumImportance] - Filter to only get messages with importance >= level
+  /// [minimumImportance] - Filter to only get messages with importance \>=
+  /// level
   /// Possible string values are:
   /// - "JOB_MESSAGE_IMPORTANCE_UNKNOWN" : The message importance isn't
   /// specified, or is unknown.
@@ -1768,7 +1770,7 @@ class ProjectsLocationsJobsMessagesResource {
   /// returned by an earlier call. This will cause the next page of results to
   /// be returned.
   ///
-  /// [startTime] - If specified, return only messages with timestamps >=
+  /// [startTime] - If specified, return only messages with timestamps \>=
   /// start_time. The default is the job creation time (i.e. beginning of
   /// messages).
   ///
@@ -3620,8 +3622,8 @@ class CounterUpdate {
 
   /// The service-generated short identifier for this counter.
   ///
-  /// The short_id -> (name, metadata) mapping is constant for the lifetime of a
-  /// job.
+  /// The short_id -\> (name, metadata) mapping is constant for the lifetime of
+  /// a job.
   core.String? shortId;
 
   /// List of strings, for Set.
@@ -5549,7 +5551,7 @@ class Job {
   /// map are UTF8 strings that comply with the following restrictions: * Keys
   /// must conform to regexp: \p{Ll}\p{Lo}{0,62} * Values must conform to
   /// regexp: \[\p{Ll}\p{Lo}\p{N}_-\]{0,63} * Both keys and values are
-  /// additionally constrained to be <= 128 bytes in size.
+  /// additionally constrained to be \<= 128 bytes in size.
   core.Map<core.String, core.String>? labels;
 
   /// The
@@ -9504,7 +9506,7 @@ class SpannerIODetails {
 /// A representation of an int64, n, that is immune to precision loss when
 /// encoded in JSON.
 class SplitInt64 {
-  /// The high order bits, including the sign: n >> 32.
+  /// The high order bits, including the sign: n \>\> 32.
   core.int? highBits;
 
   /// The low order bits: n & 0xffffffff.

--- a/generated/googleapis_beta/lib/documentai/v1beta3.dart
+++ b/generated/googleapis_beta/lib/documentai/v1beta3.dart
@@ -9225,7 +9225,7 @@ typedef GoogleRpcStatus = $Status;
 /// toProto(UIColor* color) { CGFloat red, green, blue, alpha; if (!\[color
 /// getRed:&red green:&green blue:&blue alpha:&alpha\]) { return nil; } Color*
 /// result = \[\[Color alloc\] init\]; \[result setRed:red\]; \[result
-/// setGreen:green\]; \[result setBlue:blue\]; if (alpha <= 0.9999) { \[result
+/// setGreen:green\]; \[result setBlue:blue\]; if (alpha \<= 0.9999) { \[result
 /// setAlpha:floatWrapperWithValue(alpha)\]; } \[result autorelease\]; return
 /// result; } // ... Example (JavaScript): // ... var protoToCssColor =
 /// function(rgb_color) { var redFrac = rgb_color.red || 0.0; var greenFrac =
@@ -9235,10 +9235,10 @@ typedef GoogleRpcStatus = $Status;
 /// rgbToCssColor(red, green, blue); } var alphaFrac = rgb_color.alpha.value ||
 /// 0.0; var rgbParams = \[red, green, blue\].join(','); return \['rgba(',
 /// rgbParams, ',', alphaFrac, ')'\].join(''); }; var rgbToCssColor =
-/// function(red, green, blue) { var rgbNumber = new Number((red << 16) | (green
-/// << 8) | blue); var hexString = rgbNumber.toString(16); var missingZeros = 6
-/// - hexString.length; var resultBuilder = \['#'\]; for (var i = 0; i <
-/// missingZeros; i++) { resultBuilder.push('0'); }
+/// function(red, green, blue) { var rgbNumber = new Number((red \<\< 16) |
+/// (green \<\< 8) | blue); var hexString = rgbNumber.toString(16); var
+/// missingZeros = 6 - hexString.length; var resultBuilder = \['#'\]; for (var i
+/// = 0; i \< missingZeros; i++) { resultBuilder.push('0'); }
 /// resultBuilder.push(hexString); return resultBuilder.join(''); }; // ...
 class GoogleTypeColor {
   /// The fraction of this color that should be applied to the pixel.

--- a/generated/googleapis_beta/lib/domains/v1beta1.dart
+++ b/generated/googleapis_beta/lib/domains/v1beta1.dart
@@ -612,8 +612,8 @@ class ProjectsLocationsRegistrationsResource {
   /// expression must specify the field name, a comparison operator, and the
   /// value that you want to use for filtering. The value must be a string, a
   /// number, a boolean, or an enum value. The comparison operator should be one
-  /// of =, !=, >, <, >=, <=, or : for prefix or wildcard matches. For example,
-  /// to filter to a specific domain name, use an expression like
+  /// of =, !=, \>, \<, \>=, \<=, or : for prefix or wildcard matches. For
+  /// example, to filter to a specific domain name, use an expression like
   /// `domainName="example.com"`. You can also check for the existence of a
   /// field; for example, to find domains using custom DNS settings, use an
   /// expression like `dnsSettings.customDns:*`. You can also create compound
@@ -1767,7 +1767,7 @@ typedef ExportRegistrationRequest = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -2216,14 +2216,14 @@ class OperationMetadata {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis_beta/lib/metastore/v1beta.dart
+++ b/generated/googleapis_beta/lib/metastore/v1beta.dart
@@ -1886,7 +1886,7 @@ class ExportMetadataRequest {
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec.Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -2817,14 +2817,14 @@ class OperationMetadata {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } YAML example: bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the IAM
 /// documentation (https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis_beta/lib/networkconnectivity/v1alpha1.dart
+++ b/generated/googleapis_beta/lib/networkconnectivity/v1alpha1.dart
@@ -1526,7 +1526,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -1913,14 +1913,14 @@ typedef OperationMetadata = $OperationMetadata00;
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis_beta/lib/networksecurity/v1beta1.dart
+++ b/generated/googleapis_beta/lib/networksecurity/v1beta1.dart
@@ -1860,7 +1860,7 @@ typedef Empty = $Empty;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -2094,14 +2094,14 @@ class GoogleIamV1Binding {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class GoogleIamV1Policy {

--- a/generated/googleapis_beta/lib/policysimulator/v1beta1.dart
+++ b/generated/googleapis_beta/lib/policysimulator/v1beta1.dart
@@ -1874,14 +1874,14 @@ class GoogleIamV1Binding {
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class GoogleIamV1Policy {
@@ -2107,7 +2107,7 @@ typedef GoogleTypeDate = $Date;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"

--- a/generated/googleapis_beta/lib/privateca/v1beta1.dart
+++ b/generated/googleapis_beta/lib/privateca/v1beta1.dart
@@ -3104,7 +3104,7 @@ typedef EnableCertificateAuthorityRequest = $CertificateAuthorityRequest;
 /// CEL is a C-like expression language. The syntax and semantics of CEL are
 /// documented at https://github.com/google/cel-spec. Example (Comparison):
 /// title: "Summary size limit" description: "Determines if a summary is less
-/// than 100 chars" expression: "document.summary.size() < 100" Example
+/// than 100 chars" expression: "document.summary.size() \< 100" Example
 /// (Equality): title: "Requestor is owner" description: "Determines if
 /// requestor is the document owner" expression: "document.owner ==
 /// request.auth.claims.email" Example (Logic): title: "Public documents"
@@ -3892,14 +3892,14 @@ typedef OperationMetadata = $OperationMetadata00;
 /// "roles/resourcemanager.organizationViewer", "members": \[
 /// "user:eve@example.com" \], "condition": { "title": "expirable access",
 /// "description": "Does not grant access after Sep 2020", "expression":
-/// "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
+/// "request.time \< timestamp('2020-10-01T00:00:00.000Z')", } } \], "etag":
 /// "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: -
 /// user:mike@example.com - group:admins@example.com - domain:google.com -
 /// serviceAccount:my-project-id@appspot.gserviceaccount.com role:
 /// roles/resourcemanager.organizationAdmin - members: - user:eve@example.com
 /// role: roles/resourcemanager.organizationViewer condition: title: expirable
 /// access description: Does not grant access after Sep 2020 expression:
-/// request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
+/// request.time \< timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA=
 /// version: 3 For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
 class Policy {

--- a/generated/googleapis_beta/lib/recommendationengine/v1beta1.dart
+++ b/generated/googleapis_beta/lib/recommendationengine/v1beta1.dart
@@ -976,8 +976,8 @@ class ProjectsLocationsCatalogsEventStoresUserEventsResource {
   /// returned events. This is a sequence of terms, where each term applies some
   /// kind of a restriction to the returned user events. Use this expression to
   /// restrict results to a specific time range, or filter events by eventType.
-  /// eg: eventTime > "2012-04-23T18:25:43.511Z" eventsMissingCatalogItems
-  /// eventTime<"2012-04-23T18:25:43.511Z" eventType=search We expect only 3
+  /// eg: eventTime \> "2012-04-23T18:25:43.511Z" eventsMissingCatalogItems
+  /// eventTime\<"2012-04-23T18:25:43.511Z" eventType=search We expect only 3
   /// types of fields: * eventTime: this can be specified a maximum of 2 times,
   /// once with a less than operator and once with a greater than operator. The
   /// eventTime restrict should result in one contiguous valid eventTime range.
@@ -986,10 +986,10 @@ class ProjectsLocationsCatalogsEventStoresUserEventsResource {
   /// events for which catalog items were not found in the catalog. The default
   /// behavior is to return only those events for which catalog items were
   /// found. Some examples of valid filters expressions: * Example 1: eventTime
-  /// > "2012-04-23T18:25:43.511Z" eventTime < "2012-04-23T18:30:43.511Z" *
-  /// Example 2: eventTime > "2012-04-23T18:25:43.511Z" eventType =
+  /// \> "2012-04-23T18:25:43.511Z" eventTime \< "2012-04-23T18:30:43.511Z" *
+  /// Example 2: eventTime \> "2012-04-23T18:25:43.511Z" eventType =
   /// detail-page-view * Example 3: eventsMissingCatalogItems eventType = search
-  /// eventTime < "2018-04-23T18:30:43.511Z" * Example 4: eventTime >
+  /// eventTime \< "2018-04-23T18:30:43.511Z" * Example 4: eventTime \>
   /// "2012-04-23T18:25:43.511Z" * Example 5: eventType = search * Example 6:
   /// eventsMissingCatalogItems
   ///
@@ -1558,9 +1558,9 @@ class GoogleCloudRecommendationengineV1beta1CatalogItem {
   ///
   /// This field is repeated for supporting one catalog item belonging to
   /// several parallel category hierarchies. For example, if a shoes product
-  /// belongs to both \["Shoes & Accessories" -> "Shoes"\] and \["Sports &
-  /// Fitness" -> "Athletic Clothing" -> "Shoes"\], it could be represented as:
-  /// "categoryHierarchies": \[ { "categories": \["Shoes & Accessories",
+  /// belongs to both \["Shoes & Accessories" -\> "Shoes"\] and \["Sports &
+  /// Fitness" -\> "Athletic Clothing" -\> "Shoes"\], it could be represented
+  /// as: "categoryHierarchies": \[ { "categories": \["Shoes & Accessories",
   /// "Shoes"\]}, { "categories": \["Sports & Fitness", "Athletic Clothing",
   /// "Shoes"\] } \]
   ///

--- a/generated/googleapis_beta/lib/shared.dart
+++ b/generated/googleapis_beta/lib/shared.dart
@@ -1677,7 +1677,7 @@ class $MigrateLocationDestructivelyMetadata {
   /// - "PENDING" : The MigrateLocationDestructively request has passed
   /// precondition checks and the bucket migration will begin soon.
   /// - "CREATING_TEMP_BUCKET" : Generating a unique bucket name, storing the
-  /// source -> temp mapping in Spanner, and actually creating the temporary
+  /// source -\> temp mapping in Spanner, and actually creating the temporary
   /// bucket via Bigstore.
   /// - "TRANSFERRING_TO_TEMP" : The first STS transfer to move all objects from
   /// the source bucket to the temp bucket is underway.

--- a/generated/googleapis_beta/lib/toolresults/v1beta3.dart
+++ b/generated/googleapis_beta/lib/toolresults/v1beta3.dart
@@ -2994,7 +2994,7 @@ class GraphicsStats {
 
   /// Total frames with slow render time.
   ///
-  /// Should be <= total_frames.
+  /// Should be \<= total_frames.
   core.String? jankyFrames;
 
   /// Total "missed vsync" events.
@@ -5316,7 +5316,7 @@ class Step {
 
   /// The initial state is IN_PROGRESS.
   ///
-  /// The only legal state transitions are * IN_PROGRESS -> COMPLETE A
+  /// The only legal state transitions are * IN_PROGRESS -\> COMPLETE A
   /// PRECONDITION_FAILED will be returned if an invalid transition is
   /// requested. It is valid to create Step with a state set to COMPLETE. The
   /// state can only be set to COMPLETE once. A PRECONDITION_FAILED will be


### PR DESCRIPTION
Review commits independently.

Escaping `<>` ensures that they won't be intepreted as HTML tags and then gets stripped.

It causes a few problems in:
https://pub.dev/documentation/googleapis/latest/admin.reports_v1/ActivitiesResource/list.html

Where for some reason we get:

        -  `(((accounts)|(classroom)|(cros)|(gmail)|(calendar)|(docs)|(gplus)|(sites)|(device_management)|(drive)):\[a-z0-9_\]+\[<,<=,==,>=,>,!=\]\[^,\]+,)*(((accounts)|(classroom)|(cros)|(gmail)|(calendar)|(docs)|(gplus)|(sites)|(device_management)|(drive)):\[a-z0-9_\]+\[<,<=,==,>=,>,!=\]\[^,\]+)`.
        +  `(((accounts)|(classroom)|(cros)|(gmail)|(calendar)|(docs)|(gplus)|(sites)|(device_management)|(drive)):\[a-z0-9_\]+\[\<,\<=,==,\>=,\>,!=\]\[^,\]+,)*(((accounts)|(classroom)|(cros)|(gmail)|(calendar)|(docs)|(gplus)|(sites)|(device_management)|(drive)):\[a-z0-9_\]+\[\<,\<=,==,\>=,\>,!=\]\[^,\]+)`.

Looking at the code I couldn't figure out why we are escaping inside an back-ticks annotation... maybe there is an uneven number of backticks -- but then why isn't the backticks escaped :see_no_evil: 

I'm not sure if we can or want to fix this case, the text we get seem to be semi-garbled at placed. But most of the places we escape `<>` it seems to make sense. Even the case above it doesn't seem so bad, because we're apparently already escaping `[]` in there..