### PR TITLE
Code Analysis Fixes 1

### DIFF
--- a/googleapis_auth/lib/auth_io.dart
+++ b/googleapis_auth/lib/auth_io.dart
@@ -54,7 +54,7 @@ Future<AutoRefreshingAuthClient> clientViaApplicationDefaultCredentials({
   if (credsEnv != null && credsEnv.isNotEmpty) {
     // If env var is specific and not empty, we always try to load, even if
     // the file doesn't exist.
-    return await fromApplicationsCredentialsFile(
+    return fromApplicationsCredentialsFile(
       File(credsEnv),
       'GOOGLE_APPLICATION_CREDENTIALS',
       scopes,
@@ -77,7 +77,7 @@ Future<AutoRefreshingAuthClient> clientViaApplicationDefaultCredentials({
   }
   // Only try to load from credFile if it exists.
   if (await credFile.exists()) {
-    return await fromApplicationsCredentialsFile(
+    return fromApplicationsCredentialsFile(
       credFile,
       '`gcloud auth application-default login`',
       scopes,
@@ -85,7 +85,7 @@ Future<AutoRefreshingAuthClient> clientViaApplicationDefaultCredentials({
     );
   }
 
-  return await clientViaMetadataServer(baseClient: baseClient);
+  return clientViaMetadataServer(baseClient: baseClient);
 }
 
 /// Obtains oauth2 credentials and returns an authenticated HTTP client.

--- a/googleapis_auth/lib/src/auth_http_utils.dart
+++ b/googleapis_auth/lib/src/auth_http_utils.dart
@@ -94,8 +94,10 @@ class AutoRefreshingClient extends AutoRefreshDelegatingClient {
     this.credentials, {
     bool closeUnderlyingClient = true,
     this.quotaProject,
-  })  : assert(credentials.accessToken.type == 'Bearer'),
-        assert(credentials.refreshToken != null),
+  })  : assert(credentials.accessToken.type == 'Bearer',
+            'Access token type must be Bearer'),
+        assert(
+            credentials.refreshToken != null, 'Refresh token must not be null'),
         super(client, closeUnderlyingClient: closeUnderlyingClient) {
     authClient = AuthenticatedClient(
       baseClient,

--- a/googleapis_auth/lib/src/metadata_server_client.dart
+++ b/googleapis_auth/lib/src/metadata_server_client.dart
@@ -39,8 +39,8 @@ Future<AccessCredentials> obtainAccessCredentialsViaMetadataServer(
 /// {@macro googleapis_auth_not_close_the_baseClient}
 Future<AutoRefreshingAuthClient> clientViaMetadataServer({
   Client? baseClient,
-}) async =>
-    await clientFromFlow(
+}) =>
+    clientFromFlow(
       (c) => MetadataServerAuthorizationFlow(c),
       baseClient: baseClient,
     );

--- a/googleapis_auth/lib/src/oauth2_flows/implicit.dart
+++ b/googleapis_auth/lib/src/oauth2_flows/implicit.dart
@@ -156,7 +156,7 @@ class ImplicitFlow {
 
     _gapiAuth.callMethod('authorize', [
       js.JsObject.jsify(json),
-      (js.JsObject jsTokenObject) {
+      (jsTokenObject) {
         try {
           final result = _processToken(jsTokenObject, hybrid, responseTypes);
           completer.complete(result);

--- a/googleapis_auth/test/adc_test.dart
+++ b/googleapis_auth/test/adc_test.dart
@@ -26,7 +26,7 @@ void main() {
         credsFile,
         'test-credentials-file',
         [],
-        mockClient((Request request) async {
+        mockClient((request) async {
           final url = request.url.toString();
           if (url == 'https://accounts.google.com/o/oauth2/token') {
             expect(request.method, equals('POST'));
@@ -80,7 +80,7 @@ void main() {
         credsFile,
         'test-credentials-file',
         [],
-        mockClient((Request request) async {
+        mockClient((request) async {
           final url = request.url.toString();
           if (url == 'https://accounts.google.com/o/oauth2/token') {
             expect(request.method, equals('POST'));

--- a/googleapis_auth/test/http_client_base_test.dart
+++ b/googleapis_auth/test/http_client_base_test.dart
@@ -89,7 +89,7 @@ void main() {
           Future<Response>.value(Response.bytes([], 200));
 
       test('no-query-string', () {
-        final mock = mockClient((Request request) {
+        final mock = mockClient((request) {
           expect('${request.url}', equals('http://localhost/abc?$keyEncoded'));
           return responseF();
         });
@@ -100,7 +100,7 @@ void main() {
       });
 
       test('with-query-string', () {
-        final mock = mockClient((Request request) {
+        final mock = mockClient((request) {
           expect(
               '${request.url}', equals('http://localhost/abc?x&$keyEncoded'));
           return responseF();

--- a/googleapis_auth/test/oauth2_flows/auth_code_test.dart
+++ b/googleapis_auth/test/oauth2_flows/auth_code_test.dart
@@ -21,8 +21,7 @@ void main() {
 
   // Validation + Responses from the authorization server.
 
-  RequestHandler successFullResponse({bool? manual}) =>
-      (Request request) async {
+  RequestHandler successFullResponse({bool? manual}) => (request) async {
         expect(request.method, equals('POST'));
         expect('${request.url}',
             equals('https://accounts.google.com/o/oauth2/token'));
@@ -256,7 +255,7 @@ void main() {
         'https://www.googleapis.com/oauth2/v2/tokeninfo?access_token=my_token';
 
     test('successful', () async {
-      final http = mockClient(expectAsync1((BaseRequest request) async {
+      final http = mockClient(expectAsync1((request) async {
         expect(request.url.toString(), expectedUri);
         return Response(successfulResponseJson, 200, headers: jsonContentType);
       }), expectClose: false);
@@ -265,7 +264,7 @@ void main() {
     });
 
     test('non-200-status-code', () {
-      final http = mockClient(expectAsync1((BaseRequest request) async {
+      final http = mockClient(expectAsync1((request) async {
         expect(request.url.toString(), expectedUri);
         return Response(successfulResponseJson, 201);
       }), expectClose: false);
@@ -277,7 +276,7 @@ void main() {
 
     test('no-scope', () {
       final http = mockClient(
-        expectAsync1((BaseRequest request) async {
+        expectAsync1((request) async {
           expect(request.url.toString(), expectedUri);
           return Response(jsonEncode({}), 200, headers: jsonContentType);
         }),


### PR DESCRIPTION
A small set of fixes for code analysis rules

- avoid_types_on_closure_parameters
- prefer_asserts_with_message
- unnecessary_await_in_return