### PR TITLE
i292 hacking

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -114,16 +114,16 @@ jobs:
         working-directory: googleapis_auth
         run: dart analyze --fatal-infos .
   job_004:
-    name: "analyze_and_format; Dart 2.13.4; PKGS: _test, _test_package, generated/googleapis, generated/googleapis_beta, test_integration; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; Dart 2.13.4; PKGS: _test, _test_package, generated/googleapis, generated/googleapis_beta; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.13.4;packages:_test-_test_package-generated/googleapis-generated/googleapis_beta-test_integration;commands:format-analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.13.4;packages:_test-_test_package-generated/googleapis-generated/googleapis_beta;commands:format-analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.13.4;packages:_test-_test_package-generated/googleapis-generated/googleapis_beta-test_integration
+            os:ubuntu-latest;pub-cache-hosted;dart:2.13.4;packages:_test-_test_package-generated/googleapis-generated/googleapis_beta
             os:ubuntu-latest;pub-cache-hosted;dart:2.13.4
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -184,30 +184,17 @@ jobs:
         if: "always() && steps.generated_googleapis_beta_pub_upgrade.conclusion == 'success'"
         working-directory: generated/googleapis_beta
         run: dart analyze --fatal-infos .
-      - id: test_integration_pub_upgrade
-        name: test_integration; dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: test_integration
-        run: dart pub upgrade
-      - name: "test_integration; dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.test_integration_pub_upgrade.conclusion == 'success'"
-        working-directory: test_integration
-        run: "dart format --output=none --set-exit-if-changed ."
-      - name: "test_integration; dart analyze --fatal-infos ."
-        if: "always() && steps.test_integration_pub_upgrade.conclusion == 'success'"
-        working-directory: test_integration
-        run: dart analyze --fatal-infos .
   job_005:
-    name: "analyze_and_format; Dart 2.14.0; PKG: discoveryapis_generator; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; Dart 2.14.0; PKGS: discoveryapis_generator, test_integration; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.14.0;packages:discoveryapis_generator;commands:format-analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.14.0;packages:discoveryapis_generator-test_integration;commands:format-analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.14.0;packages:discoveryapis_generator
+            os:ubuntu-latest;pub-cache-hosted;dart:2.14.0;packages:discoveryapis_generator-test_integration
             os:ubuntu-latest;pub-cache-hosted;dart:2.14.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -228,6 +215,19 @@ jobs:
       - name: "discoveryapis_generator; dart analyze --fatal-infos ."
         if: "always() && steps.discoveryapis_generator_pub_upgrade.conclusion == 'success'"
         working-directory: discoveryapis_generator
+        run: dart analyze --fatal-infos .
+      - id: test_integration_pub_upgrade
+        name: test_integration; dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: test_integration
+        run: dart pub upgrade
+      - name: "test_integration; dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.test_integration_pub_upgrade.conclusion == 'success'"
+        working-directory: test_integration
+        run: "dart format --output=none --set-exit-if-changed ."
+      - name: "test_integration; dart analyze --fatal-infos ."
+        if: "always() && steps.test_integration_pub_upgrade.conclusion == 'success'"
+        working-directory: test_integration
         run: dart analyze --fatal-infos .
   job_006:
     name: "analyze_and_format; Dart dev; PKGS: _test, _test_package, discoveryapis_commons, discoveryapis_generator, generated/googleapis, generated/googleapis_beta, generator, googleapis_auth, test_integration; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"

--- a/googleapis_auth/CHANGELOG.md
+++ b/googleapis_auth/CHANGELOG.md
@@ -1,15 +1,18 @@
 ## 1.3.0-dev
 
 - The `secret` param in `ClientId` constructor is now optional.
+- Use the latest supported Google OAuth 2.0 URL
 - `auth_browser` library:
   - Migrated to newer `auth2` Javascript API.
   - Added support for `hostedDomain` to all applicable functions.
   - `createImplicitBrowserFlow`: added (unsupported) `enableDebugLogs` param.
     (Maybe helpful for debugging, but should not be used in production.)
-- Use the latest supported Google OAuth 2.0 URL
-- Generate a longer, secure random state token.
-- Implement code verifier logic for the desktop auth flows.
-  See https://developers.google.com/identity/protocols/oauth2/native-app#create-code-challenge
+- `auth_io` library:
+  - Generate a longer, secure random state token.
+  - Implement code verifier logic for the desktop auth flows.
+    See https://developers.google.com/identity/protocols/oauth2/native-app#create-code-challenge
+  - Added optional `codeVerifier` and `scopes` parameters to
+    `obtainAccessCredentialsViaCodeExchange`.
 
 ## 1.2.0
 

--- a/googleapis_auth/lib/auth_io.dart
+++ b/googleapis_auth/lib/auth_io.dart
@@ -10,7 +10,6 @@ import 'src/adc_utils.dart';
 import 'src/auth_http_utils.dart';
 import 'src/http_client_base.dart';
 import 'src/metadata_server_client.dart' show clientViaMetadataServer;
-import 'src/oauth2_flows/auth_code.dart';
 import 'src/oauth2_flows/authorization_code_grant_manual_flow.dart';
 import 'src/oauth2_flows/authorization_code_grant_server_flow.dart';
 import 'src/service_account_credentials.dart';
@@ -18,6 +17,8 @@ import 'src/typedefs.dart';
 
 export 'googleapis_auth.dart';
 export 'src/metadata_server_client.dart';
+export 'src/oauth2_flows/auth_code.dart'
+    show obtainAccessCredentialsViaCodeExchange;
 export 'src/service_account_client.dart';
 export 'src/typedefs.dart';
 
@@ -256,35 +257,3 @@ Future<AccessCredentials> obtainAccessCredentialsViaUserConsentManual(
       userPrompt,
       hostedDomain: hostedDomain,
     ).run();
-
-/// Obtain oauth2 [AccessCredentials] by exchanging an authorization code.
-///
-/// Running a hybrid oauth2 flow as described in the
-/// `googleapis_auth.auth_browser` library results in a `HybridFlowResult` which
-/// contains short-lived [AccessCredentials] for the client and an authorization
-/// code. This authorization code needs to be transferred to the server, which
-/// can exchange it against long-lived [AccessCredentials].
-///
-/// {@macro googleapis_auth_client_for_creds}
-///
-/// {@macro googleapis_auth_clientId_param}
-///
-/// If the authorization code was obtained using the mentioned hybrid flow, the
-/// [redirectUrl] must be `"postmessage"` (default).
-///
-/// If you obtained the authorization code using a different mechanism, the
-/// [redirectUrl] must be the same that was used to obtain the code.
-///
-/// NOTE: Only the server application will know the `client secret` - which is
-/// necessary to exchange an authorization code against access tokens.
-///
-/// NOTE: It is important to transmit the authorization code in a secure manner
-/// to the server. You should use "anti-request forgery state tokens" to guard
-/// against "cross site request forgery" attacks.
-Future<AccessCredentials> obtainAccessCredentialsViaCodeExchange(
-  Client client,
-  ClientId clientId,
-  String code, {
-  String redirectUrl = 'postmessage',
-}) =>
-    obtainAccessCredentialsUsingCode(clientId, code, redirectUrl, client);

--- a/googleapis_auth/lib/src/access_credentials.dart
+++ b/googleapis_auth/lib/src/access_credentials.dart
@@ -35,7 +35,7 @@ class AccessCredentials {
 
   Map<String, dynamic> toJson() => <String, dynamic>{
         'accessToken': accessToken,
-        'refreshToken': refreshToken,
+        if (refreshToken != null) 'refreshToken': refreshToken,
         'idToken': idToken,
         'scopes': scopes,
       };

--- a/googleapis_auth/lib/src/oauth2_flows/auth_code.dart
+++ b/googleapis_auth/lib/src/oauth2_flows/auth_code.dart
@@ -43,11 +43,10 @@ Uri createAuthenticationUri({
 }
 
 /// https://developers.google.com/identity/protocols/oauth2/native-app#create-code-challenge
-/// Between 43 and 128 = 86
 String createCodeVerifier() {
   final rnd = Random.secure();
 
-  return List.generate(86, (index) => _safe[rnd.nextInt(_safe.length)]).join();
+  return List.generate(128, (index) => _safe[rnd.nextInt(_safe.length)]).join();
 }
 
 /// See https://developers.google.com/identity/protocols/oauth2/openid-connect#createxsrftoken

--- a/googleapis_auth/lib/src/oauth2_flows/authorization_code_grant_abstract_flow.dart
+++ b/googleapis_auth/lib/src/oauth2_flows/authorization_code_grant_abstract_flow.dart
@@ -27,11 +27,11 @@ abstract class AuthorizationCodeGrantAbstractFlow implements BaseFlow {
     String redirectUri, {
     required String codeVerifier,
   }) =>
-      obtainAccessCredentialsUsingCode(
+      obtainAccessCredentialsViaCodeExchange(
+        _client,
         clientId,
         code,
-        redirectUri,
-        _client,
+        redirectUrl: redirectUri,
         codeVerifier: codeVerifier,
         scopes: scopes,
       );

--- a/googleapis_auth/lib/src/oauth2_flows/authorization_code_grant_abstract_flow.dart
+++ b/googleapis_auth/lib/src/oauth2_flows/authorization_code_grant_abstract_flow.dart
@@ -2,16 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
-import 'dart:math';
-import 'dart:typed_data';
-
-import 'package:crypto/crypto.dart';
 import 'package:http/http.dart' as http;
 
 import '../access_credentials.dart';
 import '../client_id.dart';
-import '../known_uris.dart';
 import 'auth_code.dart';
 import 'base_flow.dart';
 
@@ -42,66 +36,17 @@ abstract class AuthorizationCodeGrantAbstractFlow implements BaseFlow {
         scopes: scopes,
       );
 
-  String authenticationUri(
+  Uri authenticationUri(
     String redirectUri, {
     String? state,
     required String codeVerifier,
-  }) {
-    // TODO: Increase scopes with [include_granted_scopes].
-    final queryValues = {
-      'client_id': clientId.identifier,
-      'response_type': 'code',
-      'redirect_uri': redirectUri,
-      'scope': scopes.join(' '),
-      if (hostedDomain != null) 'hd': hostedDomain!,
-      'code_challenge': _codeVerifierShaEncode(codeVerifier),
-      'code_challenge_method': 'S256',
-      if (state != null) 'state': state,
-    };
-    return googleOauth2AuthorizationEndpoint
-        .replace(
-          queryParameters: queryValues,
-        )
-        .toString();
-  }
+  }) =>
+      createAuthenticationUri(
+        redirectUri: redirectUri,
+        clientId: clientId.identifier,
+        scopes: scopes,
+        codeVerifier: codeVerifier,
+        hostedDomain: hostedDomain,
+        state: state,
+      );
 }
-
-/// https://developers.google.com/identity/protocols/oauth2/native-app#create-code-challenge
-/// Between 43 and 128 = 86
-String createCodeVerifier() {
-  final rnd = Random.secure();
-
-  return List.generate(86, (index) => _safe[rnd.nextInt(_safe.length)]).join();
-}
-
-/// See https://developers.google.com/identity/protocols/oauth2/openid-connect#createxsrftoken
-String randomState() {
-  final rnd = Random.secure();
-
-  final list = Uint32List(6);
-  for (var i = 0; i < list.length; i++) {
-    list[i] = rnd.nextInt(1 << 32);
-  }
-
-  final value = base64UrlEncode(Uint8List.view(list.buffer));
-  return _stripBase64Equals(value);
-}
-
-String _codeVerifierShaEncode(String codeVerifier) {
-  final asciiBytes = ascii.encode(codeVerifier);
-  final sha26Bytes = sha256.convert(asciiBytes).bytes;
-  final output = base64UrlEncode(sha26Bytes);
-  return _stripBase64Equals(output);
-}
-
-String _stripBase64Equals(String value) {
-  while (value.endsWith('=')) {
-    value = value.substring(0, value.length - 1);
-  }
-  return value;
-}
-
-// https://datatracker.ietf.org/doc/html/rfc3986#section-2.3
-const _safe = '0123456789-._~'
-    'abcdefghijklmnopqrstuvwxyz'
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZ';

--- a/googleapis_auth/lib/src/oauth2_flows/authorization_code_grant_manual_flow.dart
+++ b/googleapis_auth/lib/src/oauth2_flows/authorization_code_grant_manual_flow.dart
@@ -9,6 +9,7 @@ import 'package:http/http.dart' as http;
 import '../access_credentials.dart';
 import '../client_id.dart';
 import '../typedefs.dart';
+import 'auth_code.dart';
 import 'authorization_code_grant_abstract_flow.dart';
 
 /// Runs an oauth2 authorization code grant flow using manual Copy&Paste.
@@ -43,7 +44,7 @@ class AuthorizationCodeGrantManualFlow
       authenticationUri(
         _redirectionUri,
         codeVerifier: codeVerifier,
-      ),
+      ).toString(),
     );
     // Use code to obtain credentials
     return obtainAccessCredentialsUsingCodeImpl(

--- a/googleapis_auth/lib/src/oauth2_flows/authorization_code_grant_server_flow.dart
+++ b/googleapis_auth/lib/src/oauth2_flows/authorization_code_grant_server_flow.dart
@@ -11,6 +11,7 @@ import '../access_credentials.dart';
 import '../client_id.dart';
 import '../exceptions.dart';
 import '../typedefs.dart';
+import 'auth_code.dart';
 import 'authorization_code_grant_abstract_flow.dart';
 
 /// Runs an oauth2 authorization code grant flow using an HTTP server.
@@ -52,7 +53,7 @@ class AuthorizationCodeGrantServerFlow
           redirectionUri,
           state: state,
           codeVerifier: codeVerifier,
-        ),
+        ).toString(),
       );
 
       final request = await server.first;

--- a/googleapis_auth/test/oauth2_flows/auth_code_test.dart
+++ b/googleapis_auth/test/oauth2_flows/auth_code_test.dart
@@ -46,6 +46,7 @@ void main() {
 
         final pairs = request.body.split('&');
         expect(pairs, hasLength(6));
+
         expect(
           pairs,
           containsAll([
@@ -55,7 +56,7 @@ void main() {
             'client_secret=secret',
             allOf(
               startsWith('code_verifier='),
-              hasLength(100), // happens to be the output length as implemented!
+              hasLength(142), // happens to be the output length as implemented!
             ),
             if (manual) 'redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob',
             if (!manual) _browserFlowRedirectMatcher

--- a/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_hybrid_force.js
+++ b/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_hybrid_force.js
@@ -40,7 +40,7 @@
       doneCallback({
         'token_type' : 'Bearer',
         'access_token' : 'foo_token',
-        'expires_in' : 3210,
+        'expires_at' : Date.now() + 1000 * 3210,
         'code' : 'mycode'
       });
     } else {

--- a/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_hybrid_force_test.dart
+++ b/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_hybrid_force_test.dart
@@ -5,7 +5,6 @@
 @TestOn('browser')
 import 'package:googleapis_auth/auth_browser.dart' as auth;
 import 'package:googleapis_auth/src/oauth2_flows/implicit.dart' as impl;
-import 'package:googleapis_auth/src/utils.dart' as utils;
 import 'package:test/test.dart';
 
 import 'utils.dart';
@@ -22,12 +21,11 @@ void main() {
 
     final credentials = result.credentials;
 
-    final date = DateTime.now().toUtc().add(
-        const Duration(seconds: 3210 - utils.maxExpectedTimeDiffInSeconds));
+    final date = DateTime.now().toUtc().add(const Duration(seconds: 3210));
     final difference = credentials.accessToken.expiry.difference(date);
     final seconds = difference.inSeconds;
 
-    expect(-3 <= seconds && seconds <= 3, isTrue);
+    expect(seconds, inInclusiveRange(-3, 3));
     expect(credentials.accessToken.data, 'foo_token');
     expect(credentials.refreshToken, isNull);
     expect(credentials.scopes, hasLength(2));

--- a/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_hybrid_immediate.js
+++ b/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_hybrid_immediate.js
@@ -38,7 +38,7 @@
       doneCallback({
         'token_type' : 'Bearer',
         'access_token' : 'foo_token',
-        'expires_in' : 3210,
+        'expires_at' : Date.now() + 1000 * 3210,
         'code' : 'mycode'
       });
     } else {

--- a/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_hybrid_immediate_test.dart
+++ b/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_hybrid_immediate_test.dart
@@ -5,7 +5,6 @@
 @TestOn('browser')
 import 'package:googleapis_auth/auth_browser.dart' as auth;
 import 'package:googleapis_auth/src/oauth2_flows/implicit.dart' as impl;
-import 'package:googleapis_auth/src/utils.dart' as utils;
 import 'package:test/test.dart';
 
 import 'utils.dart';
@@ -21,12 +20,11 @@ void main() {
     final result = await flow.runHybridFlow(force: false, immediate: true);
     final credentials = result.credentials;
 
-    final date = DateTime.now().toUtc().add(
-        const Duration(seconds: 3210 - utils.maxExpectedTimeDiffInSeconds));
+    final date = DateTime.now().toUtc().add(const Duration(seconds: 3210));
     final difference = credentials.accessToken.expiry.difference(date);
     final seconds = difference.inSeconds;
 
-    expect(-3 <= seconds && seconds <= 3, isTrue);
+    expect(seconds, inInclusiveRange(-3, 3));
     expect(credentials.accessToken.data, 'foo_token');
     expect(credentials.refreshToken, isNull);
     expect(credentials.scopes, hasLength(2));

--- a/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_hybrid_nonforce.js
+++ b/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_hybrid_nonforce.js
@@ -38,7 +38,7 @@
       doneCallback({
         'token_type' : 'Bearer',
         'access_token' : 'foo_token',
-        'expires_in' : 3210,
+        'expires_at' : Date.now() + 1000 * 3210,
         'code' : 'mycode'
       });
     } else {

--- a/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_hybrid_nonforce_test.dart
+++ b/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_hybrid_nonforce_test.dart
@@ -5,7 +5,6 @@
 @TestOn('browser')
 import 'package:googleapis_auth/auth_browser.dart' as auth;
 import 'package:googleapis_auth/src/oauth2_flows/implicit.dart' as impl;
-import 'package:googleapis_auth/src/utils.dart' as utils;
 import 'package:test/test.dart';
 
 import 'utils.dart';
@@ -21,12 +20,11 @@ void main() {
     final result = await flow.runHybridFlow(force: false);
     final credentials = result.credentials;
 
-    final date = DateTime.now().toUtc().add(
-        const Duration(seconds: 3210 - utils.maxExpectedTimeDiffInSeconds));
+    final date = DateTime.now().toUtc().add(const Duration(seconds: 3210));
     final difference = credentials.accessToken.expiry.difference(date);
     final seconds = difference.inSeconds;
 
-    expect(-3 <= seconds && seconds <= 3, isTrue);
+    expect(seconds, inInclusiveRange(-3, 3));
     expect(credentials.accessToken.data, 'foo_token');
     expect(credentials.refreshToken, isNull);
     expect(credentials.scopes, hasLength(2));

--- a/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_immediate.js
+++ b/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_immediate.js
@@ -38,7 +38,7 @@
       doneCallback({
         'token_type' : 'Bearer',
         'access_token' : 'foo_token',
-        'expires_in' : 3210
+        'expires_at' : Date.now() + 1000 * 3210,
       });
     } else {
       throw new Error('error');

--- a/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_immediate_test.dart
+++ b/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_immediate_test.dart
@@ -5,7 +5,6 @@
 @TestOn('browser')
 import 'package:googleapis_auth/auth_browser.dart' as auth;
 import 'package:googleapis_auth/src/oauth2_flows/implicit.dart' as impl;
-import 'package:googleapis_auth/src/utils.dart' as utils;
 import 'package:test/test.dart';
 
 import 'utils.dart';
@@ -20,12 +19,11 @@ void main() {
     final flow = await auth.createImplicitBrowserFlow(clientId, scopes);
     final credentials =
         await flow.obtainAccessCredentialsViaUserConsent(immediate: true);
-    final date = DateTime.now().toUtc().add(
-        const Duration(seconds: 3210 - utils.maxExpectedTimeDiffInSeconds));
+    final date = DateTime.now().toUtc().add(const Duration(seconds: 3210));
     final difference = credentials.accessToken.expiry.difference(date);
     final seconds = difference.inSeconds;
 
-    expect(-3 <= seconds && seconds <= 3, isTrue);
+    expect(seconds, inInclusiveRange(-3, 3));
     expect(credentials.accessToken.data, 'foo_token');
     expect(credentials.refreshToken, isNull);
     expect(credentials.scopes, hasLength(2));

--- a/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_implicit_idtoken.js
+++ b/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_implicit_idtoken.js
@@ -39,7 +39,7 @@
         'token_type': 'Bearer',
         'access_token': 'foo_token',
         'id_token': 'foo_id_token',
-        'expires_in': 3210
+        'expires_at' : Date.now() + 1000 * 3210,
       });
     } else {
       throw new Error('error');

--- a/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_implicit_idtoken_test.dart
+++ b/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_implicit_idtoken_test.dart
@@ -5,7 +5,6 @@
 @TestOn('browser')
 import 'package:googleapis_auth/auth_browser.dart' as auth;
 import 'package:googleapis_auth/src/oauth2_flows/implicit.dart' as impl;
-import 'package:googleapis_auth/src/utils.dart' as utils;
 import 'package:test/test.dart';
 
 import 'utils.dart';
@@ -21,12 +20,11 @@ void main() {
     final credentials = await flow.obtainAccessCredentialsViaUserConsent(
         responseTypes: [auth.ResponseType.idToken, auth.ResponseType.token]);
 
-    final date = DateTime.now().toUtc().add(
-        const Duration(seconds: 3210 - utils.maxExpectedTimeDiffInSeconds));
+    final date = DateTime.now().toUtc().add(const Duration(seconds: 3210));
     final difference = credentials.accessToken.expiry.difference(date);
     final seconds = difference.inSeconds;
 
-    expect(-3 <= seconds && seconds <= 3, isTrue);
+    expect(seconds, inInclusiveRange(-3, 3));
     expect(credentials.accessToken.data, 'foo_token');
     expect(credentials.refreshToken, isNull);
     expect(credentials.scopes, hasLength(2));

--- a/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_nonforce.js
+++ b/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_nonforce.js
@@ -38,7 +38,7 @@
       doneCallback({
         'token_type' : 'Bearer',
         'access_token' : 'foo_token',
-        'expires_in' : 3210
+        'expires_at' : Date.now() + 1000 * 3210,
       });
     } else {
       throw new Error('error');

--- a/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_nonforce_test.dart
+++ b/googleapis_auth/test/oauth2_flows/implicit/gapi_auth_nonforce_test.dart
@@ -5,7 +5,6 @@
 @TestOn('browser')
 import 'package:googleapis_auth/auth_browser.dart' as auth;
 import 'package:googleapis_auth/src/oauth2_flows/implicit.dart' as impl;
-import 'package:googleapis_auth/src/utils.dart' as utils;
 import 'package:test/test.dart';
 
 import 'utils.dart';
@@ -20,12 +19,11 @@ void main() {
     final flow = await auth.createImplicitBrowserFlow(clientId, scopes);
     final credentials = await flow.obtainAccessCredentialsViaUserConsent();
 
-    final date = DateTime.now().toUtc().add(
-        const Duration(seconds: 3210 - utils.maxExpectedTimeDiffInSeconds));
+    final date = DateTime.now().toUtc().add(const Duration(seconds: 3210));
     final difference = credentials.accessToken.expiry.difference(date);
     final seconds = difference.inSeconds;
 
-    expect(-3 <= seconds && seconds <= 3, isTrue);
+    expect(seconds, inInclusiveRange(-3, 3));
     expect(credentials.accessToken.data, 'foo_token');
     expect(credentials.refreshToken, isNull);
     expect(credentials.scopes, hasLength(2));

--- a/googleapis_auth/test/oauth2_flows/implicit/gapi_load_failure_test.dart
+++ b/googleapis_auth/test/oauth2_flows/implicit/gapi_load_failure_test.dart
@@ -41,7 +41,7 @@ void main() {
     } catch (error) {
       final elapsed =
           (sw.elapsed - impl.ImplicitFlow.callbackTimeout).inSeconds;
-      expect(-3 <= elapsed && elapsed <= 3, isTrue);
+      expect(elapsed, inInclusiveRange(-3, 3));
     }
   });
 }

--- a/test_integration/bin/desktop_auth_server.dart
+++ b/test_integration/bin/desktop_auth_server.dart
@@ -1,0 +1,151 @@
+import 'dart:collection';
+import 'dart:io';
+
+import 'package:googleapis_auth/auth_io.dart';
+import 'package:googleapis_auth/src/oauth2_flows/auth_code.dart';
+import 'package:http/http.dart' as http;
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:test_integration/test_integration.dart';
+
+Future<void> main() async {
+  await _Server.create();
+}
+
+class _Server {
+  static const _redirectPath = 'redirect';
+  final _cache = SplayTreeSet<CacheEntry>();
+  final HttpServer _server;
+  final _client = http.Client();
+
+  final ClientId _clientId = openClientId();
+
+  _Server(this._server);
+
+  late final serverUri =
+      Uri.http('${_server.address.host}:${_server.port}', '');
+
+  late final serverRedirectUri =
+      serverUri.replace(pathSegments: [_redirectPath]).toString();
+
+  static Future<_Server> create() async {
+    final server = await HttpServer.bind('localhost', 8080);
+    // Enable content compression
+    server.autoCompress = true;
+
+    final instance = _Server(server);
+
+    final handler = const Pipeline()
+        .addMiddleware(logRequests())
+        .addHandler(instance._handler);
+
+    shelf_io.serveRequests(server, handler);
+
+    print('Serving at ${instance.serverUri}');
+
+    return instance;
+  }
+
+  Future<Response> _handler(Request request) async {
+    print('cache size: ${_cache.length}');
+    if (request.method == 'GET') {
+      final path = request.url.path;
+      switch (path) {
+        case '':
+          final entry = _nextEntry();
+
+          final redirectUri = createAuthenticationUri(
+            codeVerifier: entry.codeVerifier,
+            state: entry.state,
+            clientId: _clientId.identifier,
+            scopes: ['https://www.googleapis.com/auth/userinfo.profile'],
+            redirectUri: serverRedirectUri,
+          );
+
+          return Response.seeOther(redirectUri);
+
+        case _redirectPath:
+          final queryParams = request.url.queryParameters;
+
+          final entries = _cache
+              .where((element) => element.state == queryParams['state'])
+              .toSet();
+
+          if (entries.length != 1) {
+            throw StateError('Could not find an entry for this response!');
+          }
+
+          final code = queryParams['code'];
+
+          if (code == null) {
+            throw StateError('The code query param is required, but missing!');
+          }
+
+          final entry = entries.single;
+
+          final credentials = await obtainAccessCredentialsViaCodeExchange(
+            _client,
+            _clientId,
+            code,
+            codeVerifier: entry.codeVerifier,
+            redirectUrl: serverRedirectUri,
+          );
+
+          _cache.remove(entry);
+
+          return Response.ok(
+            prettyJsonEncode(credentials),
+            headers: {'Content-Type': 'application/json'},
+          );
+      }
+    }
+
+    return Response.notFound('Sorry!');
+  }
+
+  CacheEntry _nextEntry() {
+    _purgeCache();
+    final entry = CacheEntry();
+    _cache.add(entry);
+    return entry;
+  }
+
+  void _purgeCache() {
+    CacheEntry? first;
+    for (;;) {
+      first = _cache.isEmpty ? null : _cache.first;
+      if (first?.expired == true) {
+        print('Removing old cache entry: $first');
+        _cache.remove(first);
+      } else {
+        break;
+      }
+    }
+  }
+}
+
+class CacheEntry extends Comparable<CacheEntry> {
+  final DateTime created;
+  final String codeVerifier;
+  final String state;
+
+  CacheEntry._(this.created, this.codeVerifier, this.state);
+
+  factory CacheEntry() =>
+      CacheEntry._(DateTime.now(), createCodeVerifier(), randomState());
+
+  bool get expired =>
+      DateTime.now().difference(created) > const Duration(minutes: 1);
+
+  @override
+  int compareTo(CacheEntry other) {
+    var value = created.compareTo(other.created);
+    if (value == 0) {
+      value = codeVerifier.compareTo(other.codeVerifier);
+    }
+    if (value == 0) {
+      value = state.compareTo(other.state);
+    }
+    return value;
+  }
+}

--- a/test_integration/mono_pkg.yaml
+++ b/test_integration/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://pub.dev/packages/mono_repo
 dart:
-- 2.13.4
+- 2.14.0
 - dev
 
 stages:

--- a/test_integration/pubspec.yaml
+++ b/test_integration/pubspec.yaml
@@ -9,6 +9,8 @@ dev_dependencies:
   build_web_compilers: ^3.0.0
   googleapis: any
   googleapis_auth: any
+  shelf: ^1.2.0
+  stack_trace: ^1.10.0
   test: ^1.16.0
   yaml: ^3.1.0
 

--- a/test_integration/pubspec.yaml
+++ b/test_integration/pubspec.yaml
@@ -1,7 +1,7 @@
 name: test_integration
 publish_to: none
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dev_dependencies:
   _discoveryapis_commons: any

--- a/test_integration/web/browser_flow.dart
+++ b/test_integration/web/browser_flow.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:html';
 
 import 'package:googleapis/oauth2/v2.dart';
@@ -27,7 +28,7 @@ Future<void> _hybridFlow() async {
 
   _log([
     'cred json',
-    creds.credentials.toJson(),
+    const JsonEncoder.withIndent(' ').convert(creds.credentials),
     '',
     'auth code',
     creds.authorizationCode,
@@ -35,11 +36,17 @@ Future<void> _hybridFlow() async {
 }
 
 Future<void> _login() async {
-  final creds = await _flow.obtainAccessCredentialsViaUserConsent();
+  final creds = await _flow.obtainAccessCredentialsViaUserConsent(
+    responseTypes: [
+      ResponseType.code,
+      ResponseType.idToken,
+      ResponseType.permission
+    ],
+  );
 
   _log([
     'cred json',
-    creds.toJson(),
+    const JsonEncoder.withIndent(' ').convert(creds),
   ].join('\n'));
 }
 

--- a/test_integration/web/index.html
+++ b/test_integration/web/index.html
@@ -9,7 +9,7 @@
 <p>
   <button id="hybrid_flow">Hybrid flow</button></p>
 
-<textarea cols="80" rows="10"> </textarea>
+<textarea cols="80" rows="30"> </textarea>
 
 </body>
 </html>


### PR DESCRIPTION
- auth: refactor code related to the authorization URL
- auth: increase the "code challenge" length to the max value - 128
- auth: refactor code to export existing code exchange API
- AccessCredential: toJson - omit refreshToken if it's null
- auth: browser flow - include scopes from the response, use expires_at
- test_integration: tweaks to the web auth demo
- test_integration: add a desktop auth server
