### PR TITLE
_discoveryapis_commons: prepare for v1.0.3

### DIFF
--- a/discoveryapis_commons/CHANGELOG.md
+++ b/discoveryapis_commons/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.3-dev
+## 1.0.3
 
 - Throw a more helpful error message when a resumable upload fails.
 
@@ -24,8 +24,8 @@
 
 ## 0.2.0
 
- - Changed `ApiRequestError` (and its subclass `DetailedApiRequestError`) from
-   extending `Error` to implementing `Exception`.
+- Changed `ApiRequestError` (and its subclass `DetailedApiRequestError`) from
+  extending `Error` to implementing `Exception`.
 
 The change from extending `Error` to implementing `Exception` should not affect
 `try {...} on DetailedApiRequestError {` blocks. But anyone catching `Error`,
@@ -33,7 +33,7 @@ The change from extending `Error` to implementing `Exception` should not affect
 
 ## 0.1.9
 
- - Added a `x-goog-api-client` header for client library identification.
+- Added a `x-goog-api-client` header for client library identification.
 
 ## 0.1.8+2
 
@@ -59,8 +59,8 @@ The change from extending `Error` to implementing `Exception` should not affect
 
 ## 0.1.5
 
-- Updates to support Dart 2.0 core library changes (wave
-  2.2). See [issue 31847][sdk#31847] for details.
+- Updates to support Dart 2.0 core library changes (wave 2.2). See [issue
+  31847][sdk#31847] for details.
 
   [sdk#31847]: https://github.com/dart-lang/sdk/issues/31847
 

--- a/discoveryapis_commons/README.md
+++ b/discoveryapis_commons/README.md
@@ -1,10 +1,8 @@
-# discoveryapis_commons
-
-A package used by client libraries generated from discovery
-documents. This package is not intended to be consumed directly.
+Used by Dart code that accesses APIs defined by the
+[API Discovery Service](https://developers.google.com/discovery/v1/reference/apis).
+This package is not intended to be consumed directly.
 
 ## Features and bugs
 
-Please file feature requests and bugs at the [issue tracker][tracker].
-
-[tracker]: https://github.com/dart-lang/discoveryapis_commons/issues
+Please file feature requests and bugs at the
+[issue tracker](https://github.com/google/googleapis.dart/issues).

--- a/discoveryapis_commons/pubspec.yaml
+++ b/discoveryapis_commons/pubspec.yaml
@@ -1,5 +1,5 @@
 name: _discoveryapis_commons
-version: 1.0.3-dev
+version: 1.0.3
 description: Library for use by client APIs generated from Discovery Documents.
 repository: https://github.com/google/googleapis.dart/tree/master/discoveryapis_commons
 


### PR DESCRIPTION
Also did some cleanup to README and CHANGELOG

Towards https://github.com/google/googleapis.dart/issues/404
