### PR TITLE
wip fix(firestore)!: runAggregationQuery gets a JSON array

### DIFF
--- a/discovery/googleapis/firestore__v1.json
+++ b/discovery/googleapis/firestore__v1.json
@@ -3088,23 +3088,26 @@
         "RunAggregationQueryResponse": {
             "description": "The response for Firestore.RunAggregationQuery.",
             "id": "RunAggregationQueryResponse",
-            "properties": {
-                "readTime": {
-                    "description": "The time at which the aggregate value is valid for.",
-                    "format": "google-datetime",
-                    "type": "string"
+            "items": {
+                "properties": {
+                    "readTime": {
+                        "description": "The time at which the aggregate value is valid for.",
+                        "format": "google-datetime",
+                        "type": "string"
+                    },
+                    "result": {
+                        "$ref": "AggregationResult",
+                        "description": "A single aggregation result. Not present when reporting partial progress."
+                    },
+                    "transaction": {
+                        "description": "The transaction that was started as part of this request. Only present on the first response when the request requested to start a new transaction.",
+                        "format": "byte",
+                        "type": "string"
+                    }
                 },
-                "result": {
-                    "$ref": "AggregationResult",
-                    "description": "A single aggregation result. Not present when reporting partial progress."
-                },
-                "transaction": {
-                    "description": "The transaction that was started as part of this request. Only present on the first response when the request requested to start a new transaction.",
-                    "format": "byte",
-                    "type": "string"
-                }
+                "type": "object"
             },
-            "type": "object"
+            "type": "array"
         },
         "RunQueryRequest": {
             "description": "The request for Firestore.RunQuery.",

--- a/generated/googleapis/lib/firestore/v1.dart
+++ b/generated/googleapis/lib/firestore/v1.dart
@@ -1573,8 +1573,10 @@ class ProjectsDatabasesDocumentsResource {
       body: body_,
       queryParams: queryParams_,
     );
-    return RunAggregationQueryResponse.fromJson(
-        response_ as core.Map<core.String, core.dynamic>);
+    return (response_ as core.List)
+        .map((value) => RunAggregationQueryResponseElement.fromJson(
+            value as core.Map<core.String, core.dynamic>))
+        .toList();
   }
 
   /// Runs a query.
@@ -4280,8 +4282,7 @@ class RunAggregationQueryRequest {
       };
 }
 
-/// The response for Firestore.RunAggregationQuery.
-class RunAggregationQueryResponse {
+class RunAggregationQueryResponseElement {
   /// The time at which the aggregate value is valid for.
   core.String? readTime;
 
@@ -4303,13 +4304,13 @@ class RunAggregationQueryResponse {
         convert.base64.encode(bytes_).replaceAll('/', '_').replaceAll('+', '-');
   }
 
-  RunAggregationQueryResponse({
+  RunAggregationQueryResponseElement({
     this.readTime,
     this.result,
     this.transaction,
   });
 
-  RunAggregationQueryResponse.fromJson(core.Map json_)
+  RunAggregationQueryResponseElement.fromJson(core.Map json_)
       : this(
           readTime: json_.containsKey('readTime')
               ? json_['readTime'] as core.String
@@ -4329,6 +4330,10 @@ class RunAggregationQueryResponse {
         if (transaction != null) 'transaction': transaction!,
       };
 }
+
+/// The response for Firestore.RunAggregationQuery.
+typedef RunAggregationQueryResponse
+    = core.List<RunAggregationQueryResponseElement>;
 
 /// The request for Firestore.RunQuery.
 class RunQueryRequest {


### PR DESCRIPTION
The generated code for `ProjectsDatabasesDocumentsResource.runAggregationQuery` contains a type error.  It expects to decode the response as a JSON object, but gets an array.

Details: https://github.com/googleapis/googleapis/blob/master/google/firestore/v1/firestore.proto#L154

BREAKING: This change makes `RunAggregationQueryResponse` a `List`. Users of `runAggregationQuery` should access `RunAggregationQueryResponse.single`.

Fixes #517.