### PR TITLE
Add 'prompt=consent&access_type=offline' to request to get refresh token

### DIFF
--- a/googleapis_auth/lib/src/oauth2_flows/auth_code.dart
+++ b/googleapis_auth/lib/src/oauth2_flows/auth_code.dart
@@ -120,6 +120,8 @@ Future<AccessCredentials> obtainAccessCredentialsViaCodeExchange(
       if (codeVerifier != null) 'code_verifier': codeVerifier,
       'grant_type': 'authorization_code',
       'redirect_uri': redirectUrl,
+      'prompt': 'consent',
+      'access_type': 'offline',
     },
   );
   final accessToken = parseAccessToken(jsonMap);


### PR DESCRIPTION
If a user logs in using Google more than once, the second and subsequent times they are not provided with a refresh token, which causes the following exception:

```
'package:googleapis_auth/src/auth_http_utils.dart': Failed assertion: line 98 pos 16: 'credentials.refreshToken != null': is not true.
auth_http_utils.dart:98
```

The issue is explained here:

https://stackoverflow.com/a/10857806/3950982

The fix is to add `prompt=consent&access_type=offline` to the request, to require the user to consent to Google login each time.