### PR TITLE
Handle Auth popup close

### DIFF
--- a/googleapis_auth/lib/src/oauth2_flows/token_model.dart
+++ b/googleapis_auth/lib/src/oauth2_flows/token_model.dart
@@ -65,11 +65,25 @@ Future<AccessCredentials> requestAccessCredentials({
     completer.complete(creds);
   }
 
+  void errorCallback(gis.GoogleIdentityServicesError? error) {
+    if (error != null) {
+      completer.completeError(
+        AuthenticationException(
+          error.type.toString(),
+          errorDescription: error.message,
+          errorUri:
+              'https://developers.google.com/identity/oauth2/web/reference/js-reference#TokenClientConfig',
+        ),
+      );
+    }
+  }
+
   final config = gis.TokenClientConfig(
     callback: allowInterop(callback),
     client_id: clientId,
     scope: scopes.toList(),
     prompt: prompt,
+    error_callback: allowInterop(errorCallback),
   );
 
   final client = gis.oauth2.initTokenClient(config);
@@ -125,6 +139,19 @@ Future<CodeResponse> requestAuthorizationCode({
     ));
   }
 
+  void errorCallback(gis.GoogleIdentityServicesError? error) {
+    if (error != null) {
+      completer.completeError(
+        AuthenticationException(
+          error.type.toString(),
+          errorDescription: error.message,
+          errorUri:
+              'https://developers.google.com/identity/oauth2/web/reference/js-reference#TokenClientConfig',
+        ),
+      );
+    }
+  }
+
   final config = gis.CodeClientConfig(
     callback: allowInterop(callback),
     client_id: clientId,
@@ -132,6 +159,7 @@ Future<CodeResponse> requestAuthorizationCode({
     state: state,
     login_hint: hint,
     hd: hostedDomain,
+    error_callback: allowInterop(errorCallback),
   );
 
   final client = gis.oauth2.initCodeClient(config);


### PR DESCRIPTION
`CodeClientConfig` was missing `error_callback`. This made it impossible to detect popup close.

Probably the biggest issue of not having this `error_callback` is that the Future will actually never complete when the user closes the popup. The app will hang on the await infinitely.

```
final authCode = await requestAuthorizationCode(
...
```

Handling this using exception is inspired by [`google_sign_in_web`](https://github.com/flutter/packages/tree/main/packages/google_sign_in/google_sign_in_web), which is doing it the same way.
