### PR TITLE
Pass a language version to DartFormatter().

### DIFF
--- a/discoveryapis_generator/lib/src/utils.dart
+++ b/discoveryapis_generator/lib/src/utils.dart
@@ -10,7 +10,10 @@ import 'package:path/path.dart';
 final _cleanRegEx = RegExp(r'[^\w$]');
 String _cleanName(String name) => name.replaceAll(_cleanRegEx, '_');
 
-final _formatter = DartFormatter(lineEnding: '\n', pageWidth: 80);
+final _formatter = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+    lineEnding: '\n',
+    pageWidth: 80);
 
 String formatSource(String source) => _formatter.format(source);
 

--- a/discoveryapis_generator/pubspec.yaml
+++ b/discoveryapis_generator/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   _discoveryapis_commons: ^1.0.0
   args: ^2.5.0
   collection: ^1.16.0
-  dart_style: ^2.3.0
+  dart_style: ^2.3.7
   http: ^1.0.0
   meta: ^1.2.4
   path: ^1.3.3


### PR DESCRIPTION
We're in [the process of](https://github.com/dart-lang/dart_style/issues/1403) moving dart_style to [a new formatting style](https://github.com/dart-lang/dart_style/issues/1253). That involves making the formatter [aware of the language version of what it's formatting](https://github.com/dart-lang/dart_style/issues/1402).

That in turn means that the library API now lets you pass in a language version. In dart_style 2.3.7 [you can pass in a language version but the parameter is optional](https://pub.dev/documentation/dart_style/latest/dart_style/DartFormatter/DartFormatter.html). In the forthcoming 3.0.0 release, that parameter will become mandatory.

This updates the call to `DartFormatter()` to pass in the latest language version. If there's a more specific version that should be used, let me know and I'll update the PR.