### PR TITLE
Remove allowInterop calls, fix types of callbacks, and use dart:js_interop

### DIFF
--- a/googleapis_auth/CHANGELOG.md
+++ b/googleapis_auth/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 1.6.1-wip
 
 - Require `sdk: ^3.5.0`
-- Migrate to `dart:js_interop`.
 
 ## 1.6.0
 

--- a/googleapis_auth/CHANGELOG.md
+++ b/googleapis_auth/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 1.6.1-wip
 
 - Require `sdk: ^3.5.0`
+- Remove `allowInterop` calls for callbacks passed to `CodeClientConfig`,
+  `TokenClientConfig`, and `revoke` as they only accept Dart functions.
+- Fix the type of the callback passed to `revoke`.
+- Migrate to `dart:js_interop`.
 
 ## 1.6.0
 

--- a/googleapis_auth/CHANGELOG.md
+++ b/googleapis_auth/CHANGELOG.md
@@ -1,9 +1,6 @@
 ## 1.6.1-wip
 
 - Require `sdk: ^3.5.0`
-- Remove `allowInterop` calls for callbacks passed to `CodeClientConfig`,
-  `TokenClientConfig`, and `revoke` as they only accept Dart functions.
-- Fix the type of the callback passed to `revoke`.
 - Migrate to `dart:js_interop`.
 
 ## 1.6.0


### PR DESCRIPTION
TokenClientConfig, CodeClientConfig, and revoke all take Dart functions only and therefore we should not use allowInterop. Fixes the type expected by revoke to take a JS value that is compatible with the callback. Also removes uses of dart:js in favor of dart:js_interop.