### PR TITLE
feat(auth): add clientViaRefreshToken

### DIFF
--- a/googleapis_auth/CHANGELOG.md
+++ b/googleapis_auth/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.2
+## 2.3.0
 
 - Added `clientViaRefreshToken()` function for creating an
   `AutoRefreshingAuthClient` directly from a refresh token, `ClientId`, and

--- a/googleapis_auth/CHANGELOG.md
+++ b/googleapis_auth/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.2
+
+- Added `clientViaRefreshToken()` function for creating an
+  `AutoRefreshingAuthClient` directly from a refresh token, `ClientId`, and
+  scopes.
+
 ## 2.2.1
 
 - Require `google_cloud: '>=0.3.0 <0.5.0'`

--- a/googleapis_auth/lib/auth_io.dart
+++ b/googleapis_auth/lib/auth_io.dart
@@ -50,11 +50,7 @@ Future<AutoRefreshingAuthClient> clientViaApplicationDefaultCredentials({
   required List<String> scopes,
   Client? baseClient,
 }) async {
-  if (baseClient == null) {
-    baseClient = Client();
-  } else {
-    baseClient = nonClosingClient(baseClient);
-  }
+  baseClient = setupBaseClient(baseClient);
 
   // If env var specifies a file to load credentials from we'll do that.
   final credsEnv = Platform.environment['GOOGLE_APPLICATION_CREDENTIALS'];

--- a/googleapis_auth/lib/googleapis_auth.dart
+++ b/googleapis_auth/lib/googleapis_auth.dart
@@ -18,6 +18,7 @@
 /// {@canonicalFor auth_functions.authenticatedClient}
 /// {@canonicalFor auth_functions.autoRefreshingClient}
 /// {@canonicalFor auth_functions.clientViaApiKey}
+/// {@canonicalFor auth_functions.clientViaRefreshToken}
 /// {@canonicalFor auth_functions.refreshCredentials}
 /// {@canonicalFor client_id.ClientId}
 /// {@canonicalFor exceptions.AccessDeniedException}

--- a/googleapis_auth/lib/src/adc_utils.dart
+++ b/googleapis_auth/lib/src/adc_utils.dart
@@ -49,14 +49,16 @@ Future<AutoRefreshingAuthClient> fromApplicationsCredentialsFile(
     credentials as Map<String, dynamic>,
     scopes,
     baseClient,
+    fileSource: fileSource,
   );
 }
 
 Future<AutoRefreshingAuthClient> _clientViaApplicationCredentials(
   Map<String, dynamic> credentials,
   List<String> scopes,
-  Client baseClient,
-) async {
+  Client baseClient, {
+  String? fileSource,
+}) async {
   final quotaProject = credentials['quota_project_id'] as String?;
   if (credentials case {
     'type': 'authorized_user',
@@ -64,6 +66,13 @@ Future<AutoRefreshingAuthClient> _clientViaApplicationCredentials(
     'client_secret': final String? clientSecret,
     'refresh_token': final String? refreshToken,
   }) {
+    if (refreshToken == null) {
+      throw CredentialsFileException(
+        'Failed to parse JSON from credentials file from '
+        '${fileSource ?? 'the provided credentials'}'
+        ': refresh_token is missing.',
+      );
+    }
     final clientId = ClientId(clientIdString, clientSecret);
     return AutoRefreshingClient(
       baseClient,
@@ -72,8 +81,12 @@ Future<AutoRefreshingAuthClient> _clientViaApplicationCredentials(
       await refreshCredentials(
         clientId,
         AccessCredentials(
-          // Hack: Create empty credentials that have expired.
-          AccessToken('Bearer', '', DateTime(0).toUtc()),
+          // Deliberately expired — forces a token exchange immediately.
+          AccessToken(
+            'Bearer',
+            '',
+            DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+          ),
           refreshToken,
           scopes,
         ),
@@ -88,9 +101,12 @@ Future<AutoRefreshingAuthClient> _clientViaApplicationCredentials(
     'service_account_impersonation_url': final String url,
     'source_credentials': final Map<String, dynamic> source,
   }) {
-    final sourceClient = await _clientViaApplicationCredentials(source, [
-      'https://www.googleapis.com/auth/iam',
-    ], baseClient);
+    final sourceClient = await _clientViaApplicationCredentials(
+      source,
+      ['https://www.googleapis.com/auth/iam'],
+      baseClient,
+      fileSource: fileSource,
+    );
 
     final match = _impersonationUrlRegExp.firstMatch(url);
     if (match == null) {

--- a/googleapis_auth/lib/src/auth_functions.dart
+++ b/googleapis_auth/lib/src/auth_functions.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'package:http/http.dart';
 
 import 'access_credentials.dart';
+import 'access_token.dart';
 import 'auth_client.dart';
 import 'auth_endpoints.dart';
 import 'auth_http_utils.dart';
@@ -102,6 +103,49 @@ AutoRefreshingAuthClient autoRefreshingClient(
     throw ArgumentError('Refresh token in AccessCredentials was `null`.');
   }
   return AutoRefreshingClient(baseClient, authEndpoints, clientId, credentials);
+}
+
+/// Creates an [AutoRefreshingAuthClient] from a refresh token.
+///
+/// {@macro googleapis_auth_clientId_param}
+///
+/// The [refreshToken] is used to obtain and automatically refresh access
+/// tokens for the given [scopes].
+///
+/// {@macro googleapis_auth_baseClient_param}
+///
+/// {@macro googleapis_auth_close_the_client}
+/// {@macro googleapis_auth_not_close_the_baseClient}
+Future<AutoRefreshingAuthClient> clientViaRefreshToken(
+  ClientId clientId,
+  String refreshToken,
+  List<String> scopes, {
+  Client? baseClient,
+  AuthEndpoints authEndpoints = const GoogleAuthEndpoints(),
+}) async {
+  if (baseClient == null) {
+    baseClient = Client();
+  } else {
+    baseClient = nonClosingClient(baseClient);
+  }
+
+  final expiredCredentials = AccessCredentials(
+    // Deliberately expired — forces a token exchange on the first request.
+    AccessToken(
+      'Bearer',
+      '',
+      DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+    ),
+    refreshToken,
+    scopes,
+  );
+
+  return AutoRefreshingClient(
+    baseClient,
+    authEndpoints,
+    clientId,
+    expiredCredentials,
+  );
 }
 
 /// Obtains refreshed [AccessCredentials] for [clientId] and [credentials].

--- a/googleapis_auth/lib/src/auth_functions.dart
+++ b/googleapis_auth/lib/src/auth_functions.dart
@@ -34,14 +34,8 @@ import 'utils.dart';
 /// {@template googleapis_auth_not_close_the_baseClient}
 /// Closing the returned [Client] will not close [baseClient].
 /// {@endtemplate}
-Client clientViaApiKey(String apiKey, {Client? baseClient}) {
-  if (baseClient == null) {
-    baseClient = Client();
-  } else {
-    baseClient = nonClosingClient(baseClient);
-  }
-  return ApiKeyClient(baseClient, apiKey);
-}
+Client clientViaApiKey(String apiKey, {Client? baseClient}) =>
+    ApiKeyClient(setupBaseClient(baseClient), apiKey);
 
 /// Obtain a [Client] which automatically authenticates requests using
 /// [credentials].
@@ -116,36 +110,56 @@ AutoRefreshingAuthClient autoRefreshingClient(
 ///
 /// {@macro googleapis_auth_close_the_client}
 /// {@macro googleapis_auth_not_close_the_baseClient}
+///
+/// If [quotaProject] is provided, it will be added to the `X-Goog-User-Project`
+/// header for all requests.
 Future<AutoRefreshingAuthClient> clientViaRefreshToken(
   ClientId clientId,
   String refreshToken,
   List<String> scopes, {
   Client? baseClient,
   AuthEndpoints authEndpoints = const GoogleAuthEndpoints(),
+  String? quotaProject,
 }) async {
+  final bool closeUnderlyingClient;
+  final Client setupClient;
   if (baseClient == null) {
-    baseClient = Client();
+    setupClient = Client();
+    closeUnderlyingClient = true;
   } else {
-    baseClient = nonClosingClient(baseClient);
+    setupClient = nonClosingClient(baseClient);
+    closeUnderlyingClient = false;
   }
 
-  final expiredCredentials = AccessCredentials(
-    // Deliberately expired — forces a token exchange on the first request.
-    AccessToken(
-      'Bearer',
-      '',
-      DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
-    ),
-    refreshToken,
-    scopes,
-  );
+  try {
+    final credentials = await refreshCredentials(
+      clientId,
+      AccessCredentials(
+        // Deliberately expired — forces a token exchange immediately.
+        AccessToken(
+          'Bearer',
+          '',
+          DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+        ),
+        refreshToken,
+        scopes,
+      ),
+      setupClient,
+      authEndpoints: authEndpoints,
+    );
 
-  return AutoRefreshingClient(
-    baseClient,
-    authEndpoints,
-    clientId,
-    expiredCredentials,
-  );
+    return AutoRefreshingClient(
+      setupClient,
+      authEndpoints,
+      clientId,
+      credentials,
+      closeUnderlyingClient: closeUnderlyingClient,
+      quotaProject: quotaProject,
+    );
+  } catch (e) {
+    setupClient.close();
+    rethrow;
+  }
 }
 
 /// Obtains refreshed [AccessCredentials] for [clientId] and [credentials].

--- a/googleapis_auth/lib/src/http_client_base.dart
+++ b/googleapis_auth/lib/src/http_client_base.dart
@@ -90,6 +90,17 @@ class RefCountedClient extends DelegatingClient {
 Client nonClosingClient(Client baseClient) =>
     RefCountedClient(baseClient, initialRefCount: 2);
 
+/// Wraps [baseClient] so that calling [Client.close] on the returned client
+/// will not close [baseClient].
+///
+/// If [baseClient] is `null`, a new [Client] instance will be created.
+Client setupBaseClient(Client? baseClient) {
+  if (baseClient == null) {
+    return Client();
+  }
+  return nonClosingClient(baseClient);
+}
+
 class RequestImpl extends BaseRequest {
   final Stream<List<int>> _stream;
 

--- a/googleapis_auth/lib/src/oauth2_flows/base_flow.dart
+++ b/googleapis_auth/lib/src/oauth2_flows/base_flow.dart
@@ -23,11 +23,7 @@ Future<AutoRefreshingAuthClient> clientFromFlow(
   Client? baseClient,
   String? quotaProject,
 }) async {
-  if (baseClient == null) {
-    baseClient = Client();
-  } else {
-    baseClient = nonClosingClient(baseClient);
-  }
+  baseClient = setupBaseClient(baseClient);
 
   final flow = flowFactory(baseClient);
 

--- a/googleapis_auth/pubspec.yaml
+++ b/googleapis_auth/pubspec.yaml
@@ -1,5 +1,5 @@
 name: googleapis_auth
-version: 2.2.2
+version: 2.3.0
 description: Obtain Access credentials for Google services using OAuth 2.0
 repository: https://github.com/google/googleapis.dart/tree/master/googleapis_auth
 

--- a/googleapis_auth/pubspec.yaml
+++ b/googleapis_auth/pubspec.yaml
@@ -1,5 +1,5 @@
 name: googleapis_auth
-version: 2.2.1
+version: 2.2.2
 description: Obtain Access credentials for Google services using OAuth 2.0
 repository: https://github.com/google/googleapis.dart/tree/master/googleapis_auth
 

--- a/googleapis_auth/test/oauth2_test.dart
+++ b/googleapis_auth/test/oauth2_test.dart
@@ -564,7 +564,7 @@ void main() {
     group('clientViaRefreshToken', () {
       final url = Uri.parse('http://www.example.com');
 
-      test('always refreshes on first request', () async {
+      test('refreshes during creation', () async {
         var serverInvocation = 0;
 
         final client = await clientViaRefreshToken(
@@ -586,6 +586,8 @@ void main() {
           ),
         );
 
+        expect(client.credentials.accessToken.data, 'atoken');
+
         final request = RequestImpl('POST', url);
         request.headers.addAll({'foo': 'bar'});
 
@@ -594,7 +596,22 @@ void main() {
         client.close();
       });
 
-      test('notifies credentialUpdates after refresh', () async {
+      test('throws on initial refresh failure', () async {
+        await expectLater(
+          clientViaRefreshToken(
+            clientId,
+            'refresh',
+            ['s1'],
+            baseClient: mockClient(
+              expectAsync1(refreshErrorResponse),
+              expectClose: false,
+            ),
+          ),
+          throwsA(isServerRequestFailedException),
+        );
+      });
+
+      test('sends quotaProject header', () async {
         var serverInvocation = 0;
 
         final client = await clientViaRefreshToken(
@@ -605,43 +622,21 @@ void main() {
             expectAsync1((request) async {
               if (serverInvocation++ == 0) {
                 return successfulRefresh(request);
+              } else {
+                expect(
+                  request.headers,
+                  containsPair('X-Goog-User-Project', 'test-project'),
+                );
+                return Response('', 200);
               }
-              return Response('', 200);
             }, count: 2),
             expectClose: false,
           ),
-        );
-
-        var updated = false;
-        client.credentialUpdates.listen(
-          expectAsync1((newCredentials) {
-            expect(newCredentials.accessToken.type, 'Bearer');
-            expect(newCredentials.accessToken.data, 'atoken');
-            updated = true;
-          }),
-          onDone: expectAsync0(() {}),
+          quotaProject: 'test-project',
         );
 
         await client.send(RequestImpl('POST', url));
-        expect(updated, isTrue);
         client.close();
-      });
-
-      test('throws on refresh failure', () async {
-        final client = await clientViaRefreshToken(
-          clientId,
-          'refresh',
-          ['s1'],
-          baseClient: mockClient(
-            expectAsync1(refreshErrorResponse),
-            expectClose: false,
-          ),
-        );
-
-        expect(
-          client.send(RequestImpl('POST', url)),
-          throwsA(isServerRequestFailedException),
-        );
       });
     });
 

--- a/googleapis_auth/test/oauth2_test.dart
+++ b/googleapis_auth/test/oauth2_test.dart
@@ -561,6 +561,90 @@ void main() {
       });
     });
 
+    group('clientViaRefreshToken', () {
+      final url = Uri.parse('http://www.example.com');
+
+      test('always refreshes on first request', () async {
+        var serverInvocation = 0;
+
+        final client = await clientViaRefreshToken(
+          clientId,
+          'refresh',
+          ['s1', 's2'],
+          baseClient: mockClient(
+            expectAsync1((request) async {
+              if (serverInvocation++ == 0) {
+                // First call must be a token exchange, not the real request.
+                expect(request.headers, isNot(contains('foo')));
+                return successfulRefresh(request);
+              } else {
+                expect(request.headers, containsPair('foo', 'bar'));
+                return Response('', 200);
+              }
+            }, count: 2),
+            expectClose: false,
+          ),
+        );
+
+        final request = RequestImpl('POST', url);
+        request.headers.addAll({'foo': 'bar'});
+
+        final response = await client.send(request);
+        expect(response.statusCode, 200);
+        client.close();
+      });
+
+      test('notifies credentialUpdates after refresh', () async {
+        var serverInvocation = 0;
+
+        final client = await clientViaRefreshToken(
+          clientId,
+          'refresh',
+          ['s1'],
+          baseClient: mockClient(
+            expectAsync1((request) async {
+              if (serverInvocation++ == 0) {
+                return successfulRefresh(request);
+              }
+              return Response('', 200);
+            }, count: 2),
+            expectClose: false,
+          ),
+        );
+
+        var updated = false;
+        client.credentialUpdates.listen(
+          expectAsync1((newCredentials) {
+            expect(newCredentials.accessToken.type, 'Bearer');
+            expect(newCredentials.accessToken.data, 'atoken');
+            updated = true;
+          }),
+          onDone: expectAsync0(() {}),
+        );
+
+        await client.send(RequestImpl('POST', url));
+        expect(updated, isTrue);
+        client.close();
+      });
+
+      test('throws on refresh failure', () async {
+        final client = await clientViaRefreshToken(
+          clientId,
+          'refresh',
+          ['s1'],
+          baseClient: mockClient(
+            expectAsync1(refreshErrorResponse),
+            expectClose: false,
+          ),
+        );
+
+        expect(
+          client.send(RequestImpl('POST', url)),
+          throwsA(isServerRequestFailedException),
+        );
+      });
+    });
+
     group('Service Account Access', () {
       test('clientViaServiceAccount exposes credentials', () async {
         final credentials = ServiceAccountCredentials.fromJson({


### PR DESCRIPTION
Adds `clientViaRefreshToken`, a convenience function for creating an `AutoRefreshingAuthClient` directly from a refresh token, without needing to manually construct expired `AccessCredentials`.
