### PR TITLE
fix(auth): make googleapis_auth web-compatible by removing transitive dart:io imports

### DIFF
--- a/googleapis_auth/CHANGELOG.md
+++ b/googleapis_auth/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.2
+
+- Fix web compatibility by removing transitive `dart:io` and
+  `package:google_cloud` imports from the core `googleapis_auth.dart` library.
+
 ## 2.3.1
 
 - Require `google_cloud: '>=0.3.0 <0.6.0'`
@@ -27,7 +32,7 @@
 - Application Default Credentials (ADC) now propagate `quota_project_id` for
   Service Account credentials.
 - Added `CredentialsFileException` and `AuthorizationCallbackException` classes.
-- Replaced generic exception and error throws (such as `Exception`, `ArgumentError`, 
+- Replaced generic exception and error throws (such as `Exception`, `ArgumentError`,
   and `UnsupportedError`) with more specific exception types throughout the package to
   improve error handling and debuggability.
 - `AuthClientSigningExtension.sign()` now accepts an optional `serviceAccountEmail`
@@ -72,7 +77,7 @@
 
 ## 1.5.1
 
-- `auth_browser.dart`: handle pop-up closed errors correctly. 
+- `auth_browser.dart`: handle pop-up closed errors correctly.
 
 ## 1.5.0
 
@@ -81,7 +86,7 @@
 ## 1.4.2
 
 - Require Dart 3.2 or later.
-- Require 
+- Require
   - `google_identity_services_web: ^0.3.0`
   - `http: ^1.0.0`
 
@@ -112,7 +117,7 @@
 #### `auth_io.dart` library
 
 - Added an optional `listenPort` parameter to `clientViaUserConsent`
-  and `obtainAccessCredentialsViaUserConsent`. 
+  and `obtainAccessCredentialsViaUserConsent`.
 
 ## 1.3.1
 

--- a/googleapis_auth/lib/src/auth_client.dart
+++ b/googleapis_auth/lib/src/auth_client.dart
@@ -6,7 +6,7 @@
 
 import 'package:http/http.dart';
 
-import '../auth_io.dart';
+import 'access_credentials.dart';
 
 /// A authenticated HTTP client.
 abstract class AuthClient implements Client {

--- a/googleapis_auth/lib/src/auth_client_signing_extension.dart
+++ b/googleapis_auth/lib/src/auth_client_signing_extension.dart
@@ -9,9 +9,10 @@ library;
 
 import 'dart:convert';
 
-import 'package:google_cloud/google_cloud.dart';
 import 'iam_signer.dart';
 import 'impersonated_auth_client.dart';
+import 'metadata_server_stub.dart'
+    if (dart.library.io) 'metadata_server_io.dart';
 import 'service_account_credentials.dart';
 
 /// Extension providing smart signing capabilities for [AuthClient].
@@ -49,6 +50,8 @@ extension AuthClientSigningExtension on AuthClient {
   /// The result is cached for the lifetime of the Dart process.
   ///
   /// If [refresh] is `true`, the cache is cleared and the value is re-computed.
+  ///
+  /// Throws [UnsupportedError] on web platforms.
   Future<String> getServiceAccountEmail({bool refresh = false}) async =>
       await serviceAccountEmailFromMetadataServer(
         client: this,
@@ -74,7 +77,10 @@ extension AuthClientSigningExtension on AuthClient {
   ///     `signBlob` endpoint.
   ///     - The [serviceAccountEmail] can be provided to specify which service
   ///       account to use. If not provided, it will be inferred from the
-  ///       environment (e.g., GCE metadata server).
+  ///       environment (e.g., GCE metadata server). Note: On web platforms,
+  ///       [serviceAccountEmail] must be explicitly provided; otherwise,
+  ///       attempting to infer it from the GCE metadata server will throw
+  ///       an [UnsupportedError].
   ///     - The [endpoint] is an optional custom IAM Credentials API endpoint.
   ///       This is useful when working with different universe domains. If not
   ///       provided, the endpoint is automatically determined from the

--- a/googleapis_auth/lib/src/iam_signer.dart
+++ b/googleapis_auth/lib/src/iam_signer.dart
@@ -6,9 +6,10 @@
 
 import 'dart:convert';
 
-import 'package:google_cloud/google_cloud.dart';
 import 'package:http/http.dart' as http;
 
+import 'metadata_server_stub.dart'
+    if (dart.library.io) 'metadata_server_io.dart';
 import 'utils.dart';
 
 /// Signs the given [data] using the IAM Credentials API.
@@ -22,6 +23,9 @@ import 'utils.dart';
 ///
 /// [serviceAccountEmail] is the email of the service account to sign with.
 /// If not provided, it will be fetched from the GCE metadata server.
+/// Note: On web platforms, [serviceAccountEmail] must be explicitly provided;
+/// otherwise, attempting to fetch it from the GCE metadata server will throw
+/// an [UnsupportedError].
 ///
 /// [delegates] specifies the sequence of service accounts in a delegation
 /// chain.

--- a/googleapis_auth/lib/src/metadata_server_io.dart
+++ b/googleapis_auth/lib/src/metadata_server_io.dart
@@ -1,0 +1,14 @@
+// Copyright 2026 Google LLC
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+import 'package:google_cloud/google_cloud.dart' as gc;
+import 'package:http/http.dart' as http;
+
+Future<String> serviceAccountEmailFromMetadataServer({
+  required http.Client client,
+  bool refresh = false,
+}) =>
+    gc.serviceAccountEmailFromMetadataServer(client: client, refresh: refresh);

--- a/googleapis_auth/lib/src/metadata_server_stub.dart
+++ b/googleapis_auth/lib/src/metadata_server_stub.dart
@@ -1,0 +1,14 @@
+// Copyright 2026 Google LLC
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+import 'package:http/http.dart' as http;
+
+Future<String> serviceAccountEmailFromMetadataServer({
+  required http.Client client,
+  bool refresh = false,
+}) {
+  throw UnsupportedError('Metadata server is not supported on this platform.');
+}

--- a/googleapis_auth/pubspec.yaml
+++ b/googleapis_auth/pubspec.yaml
@@ -1,5 +1,5 @@
 name: googleapis_auth
-version: 2.3.1
+version: 2.3.2
 description: Obtain Access credentials for Google services using OAuth 2.0
 repository: https://github.com/google/googleapis.dart/tree/master/googleapis_auth
 


### PR DESCRIPTION
- Replace the import of `../auth_io.dart` in `auth_client.dart` with `access_credentials.dart` to avoid importing `dart:io` on the web.
- Introduce conditional imports for `serviceAccountEmailFromMetadataServer` in `auth_client_signing_extension.dart` and `iam_signer.dart`. This prevents importing `package:google_cloud` (which depends on `dart:io`) on the web, while retaining full functionality on the Dart VM.
- Document that GCE metadata server fallback/querying is unsupported on the web and throws UnsupportedError, meaning `serviceAccountEmail` is required on the web for signing.
- Prepares v2.3.2.

Fixes https://github.com/google/googleapis.dart/issues/746
