### PR TITLE
ci: restrict workflow token permissions to satisfy zizmor scan

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.6.3
+# Created with package:mono_repo v6.7.2
 name: Dart CI
 on:
   push:
@@ -13,7 +13,8 @@ defaults:
     shell: bash
 env:
   PUB_ENVIRONMENT: bot.github
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   job_001:
@@ -35,8 +36,10 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.6.3
+        run: dart pub global activate mono_repo 6.7.2
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
@@ -60,6 +63,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: _test_pub_upgrade
         name: _test; dart pub upgrade
         run: dart pub upgrade
@@ -162,6 +167,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: _test_pub_upgrade
         name: _test; dart pub upgrade
         run: dart pub upgrade
@@ -300,6 +307,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: _test_package_pub_upgrade
         name: _test_package; dart pub upgrade
         run: dart pub upgrade
@@ -334,6 +343,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: discoveryapis_commons_pub_upgrade
         name: discoveryapis_commons; dart pub upgrade
         run: dart pub upgrade
@@ -368,6 +379,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: discoveryapis_generator_pub_upgrade
         name: discoveryapis_generator; dart pub upgrade
         run: dart pub upgrade
@@ -402,6 +415,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: generated_googleapis_pub_upgrade
         name: generated/googleapis; dart pub upgrade
         run: dart pub upgrade
@@ -436,6 +451,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: generated_googleapis_beta_pub_upgrade
         name: generated/googleapis_beta; dart pub upgrade
         run: dart pub upgrade
@@ -470,6 +487,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: googleapis_auth_pub_upgrade
         name: googleapis_auth; dart pub upgrade
         run: dart pub upgrade
@@ -504,6 +523,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: googleapis_auth_pub_upgrade
         name: googleapis_auth; dart pub upgrade
         run: dart pub upgrade
@@ -538,6 +559,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: _test_package_pub_upgrade
         name: _test_package; dart pub upgrade
         run: dart pub upgrade
@@ -572,6 +595,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: discoveryapis_commons_pub_upgrade
         name: discoveryapis_commons; dart pub upgrade
         run: dart pub upgrade
@@ -606,6 +631,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: discoveryapis_generator_pub_upgrade
         name: discoveryapis_generator; dart pub upgrade
         run: dart pub upgrade
@@ -640,6 +667,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: generated_googleapis_pub_upgrade
         name: generated/googleapis; dart pub upgrade
         run: dart pub upgrade
@@ -674,6 +703,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: generated_googleapis_beta_pub_upgrade
         name: generated/googleapis_beta; dart pub upgrade
         run: dart pub upgrade
@@ -708,6 +739,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: googleapis_auth_pub_upgrade
         name: googleapis_auth; dart pub upgrade
         run: dart pub upgrade
@@ -742,6 +775,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: googleapis_auth_pub_upgrade
         name: googleapis_auth; dart pub upgrade
         run: dart pub upgrade
@@ -776,6 +811,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: _googleapis_auth_e2e_pub_upgrade
         name: _googleapis_auth_e2e; dart pub upgrade
         run: dart pub upgrade
@@ -824,6 +861,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - id: _googleapis_auth_e2e_pub_upgrade
         name: _googleapis_auth_e2e; dart pub upgrade
         run: dart pub upgrade

--- a/.github/workflows/verify_examples.yml
+++ b/.github/workflows/verify_examples.yml
@@ -12,6 +12,8 @@ defaults:
     shell: bash
 env:
   PUB_ENVIRONMENT: bot.github
+permissions:
+  contents: read
 
 jobs:
   verify_examples:
@@ -30,6 +32,8 @@ jobs:
       with:
         sdk: dev
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      with:
+        persist-credentials: false
     - run: |
         pushd discoveryapis_generator
         dart pub upgrade

--- a/mono_repo.yaml
+++ b/mono_repo.yaml
@@ -3,6 +3,8 @@ self_validate: analyze_and_format
 
 github:
   cron: '0 0 * * 0' # “At 00:00 (UTC) on Sunday.”
+  permissions:
+    contents: read
 
 merge_stages:
 - analyze_and_format

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.6.3
+# Created with package:mono_repo v6.7.2
 
 # Support built in commands on windows out of the box.
 


### PR DESCRIPTION
Google's organization-wide GitHub Actions security scanner (zizmor) requires workflows to use restricted token permissions and avoid overly broad access (rule excessive-permissions).

* Configure `permissions: contents: read` in `mono_repo.yaml`.
* Regenerate `.github/workflows/dart.yml` using `mono_repo` v6.7.2, replacing `read-all` permissions and adding `persist-credentials: false`.
* Add explicit `contents: read` permissions and `persist-credentials: false` to `.github/workflows/verify_examples.yml`.
