### PR TITLE
feat(commons): include error details in DetailedApiRequestError.toString()

### DIFF
--- a/discoveryapis_commons/CHANGELOG.md
+++ b/discoveryapis_commons/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.0.8-wip
 
+- Include error details and the JSON error response in
+  `DetailedApiRequestError.toString()`.
 - Fix detection of web usage.
 - Require `sdk: ^3.9.0`
 

--- a/discoveryapis_commons/lib/src/requests.dart
+++ b/discoveryapis_commons/lib/src/requests.dart
@@ -183,8 +183,19 @@ class DetailedApiRequestError extends ApiRequestError {
   }) : super(message);
 
   @override
-  String toString() =>
-      'DetailedApiRequestError(status: $status, message: $message)';
+  String toString() {
+    final buffer = StringBuffer(
+      'DetailedApiRequestError(status: $status, message: $message',
+    );
+    if (errors.isNotEmpty) {
+      buffer.write(', errors: [${errors.join(', ')}]');
+    }
+    if (jsonResponse != null) {
+      buffer.write(', jsonResponse: $jsonResponse');
+    }
+    buffer.write(')');
+    return buffer.toString();
+  }
 }
 
 /// Instances of this class can be added to a [DetailedApiRequestError] to
@@ -244,4 +255,18 @@ class ApiRequestErrorDetail {
       locationType = originalJson['locationType'] as String?,
       extendedHelp = originalJson['extendedHelp'] as String?,
       sendReport = originalJson['sendReport'] as String?;
+
+  @override
+  String toString() {
+    final values = <String>[
+      if (domain != null) 'domain: $domain',
+      if (reason != null) 'reason: $reason',
+      if (message != null) 'message: $message',
+      if (location != null) 'location: $location',
+      if (locationType != null) 'locationType: $locationType',
+      if (extendedHelp != null) 'extendedHelp: $extendedHelp',
+      if (sendReport != null) 'sendReport: $sendReport',
+    ];
+    return 'ApiRequestErrorDetail(${values.join(', ')})';
+  }
 }

--- a/discoveryapis_commons/test/discoveryapis_commons_test.dart
+++ b/discoveryapis_commons/test/discoveryapis_commons_test.dart
@@ -965,6 +965,41 @@ void main() {
             );
       });
 
+      test('detailed-error-toString-includes-json-response', () {
+        makeDetailed400Error();
+        requester
+            .request('abc', 'GET')
+            .onError(
+              expectAsync2((error, stack) {
+                final e = error as DetailedApiRequestError;
+                final string = e.toString();
+                expect(string, startsWith('DetailedApiRequestError('));
+                expect(string, contains('status: 42'));
+                expect(string, contains('message: foo'));
+                expect(
+                  string,
+                  contains('jsonResponse: {error: {code: 42, message: foo}}'),
+                );
+              }),
+            );
+      });
+
+      test('error-with-multiple-errors-toString-includes-details', () {
+        makeErrorsError();
+        requester
+            .request('abc', 'GET')
+            .onError(
+              expectAsync2((error, stack) {
+                final e = error as DetailedApiRequestError;
+                final string = e.toString();
+                expect(string, contains('errors: [ApiRequestErrorDetail('));
+                expect(string, contains('reason: InvalidEmailError'));
+                expect(string, contains('domain: account'));
+                expect(string, contains('message: error'));
+              }),
+            );
+      });
+
       test('normal-199', () {
         makeNormal199Error();
         expect(requester.request('abc', 'GET'), throwsA(isApiRequestError));


### PR DESCRIPTION
Closes #70

`DetailedApiRequestError.toString()` currently renders only `status` and `message`, dropping both the parsed `errors` list and the full `jsonResponse` payload — which is often where the actionable detail of an API failure lives.

This change:
- Appends the parsed `errors` list (when non-empty) to the string representation.
- Appends the full decoded `jsonResponse` (when available).
- Adds `toString()` for `ApiRequestErrorDetail` so each error detail renders readably.
- Adds regression tests covering both a plain JSON error and one with multiple `errors` entries.
- Updates the changelog.

Verified against the real source in `discoveryapis_commons/lib/src/requests.dart`; no open PR already addresses this.