### PR TITLE
chore(discoveryapis_commons): prepare 1.0.8 release

### DIFF
--- a/discoveryapis_commons/CHANGELOG.md
+++ b/discoveryapis_commons/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.8-wip
+## 1.0.8
 
 - Fix detection of web usage.
 - Require `sdk: ^3.9.0`

--- a/discoveryapis_commons/pubspec.yaml
+++ b/discoveryapis_commons/pubspec.yaml
@@ -1,5 +1,5 @@
 name: _discoveryapis_commons
-version: 1.0.8-wip
+version: 1.0.8
 description: Library for use by client APIs generated from Discovery Documents.
 repository: https://github.com/google/googleapis.dart/tree/master/discoveryapis_commons
 


### PR DESCRIPTION
### Rationale
Prepare `_discoveryapis_commons` for release as version `1.0.8` on pub.dev to ship WebAssembly (`dart2wasm`) web detection support and the updated minimum SDK constraint (`sdk: ^3.9.0`).

### Summary of Changes
- Updated `version` to `1.0.8` in `discoveryapis_commons/pubspec.yaml`.
- Finalized `1.0.8` release section in `discoveryapis_commons/CHANGELOG.md`:
  - Fix detection of web usage (support WebAssembly via `dart.library.js_interop`).
  - Require `sdk: ^3.9.0`.

### Verification
- Executed `dart analyze discoveryapis_commons`: 0 issues found.
- Executed `dart test discoveryapis_commons`: 57/57 tests passing.
